### PR TITLE
feat: add skills management command with octopus-fix skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octp/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI tool for Octopus — AI-powered PR review and codebase intelligence",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "src/skiils"
   ],
   "dependencies": {
     "chalk": "^5.4.1",

--- a/src/commands/skills.ts
+++ b/src/commands/skills.ts
@@ -1,0 +1,154 @@
+import { Command } from "commander";
+import { readdir, readFile, mkdir, writeFile, access } from "node:fs/promises";
+import { resolve, join, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import chalk from "chalk";
+import { success, error, info, table } from "../lib/output.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const SKILLS_DIR = resolve(__dirname, "..", "..", "src", "skiils");
+
+const CLAUDE_DIR = join(homedir(), ".claude", "commands");
+const CODEX_DIR = join(homedir(), ".agents", "skills");
+
+interface SkillMeta {
+  fileName: string;
+  name: string;
+  description: string;
+}
+
+function parseSkillFrontmatter(content: string): { name: string; description: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return { name: "", description: "" };
+
+  const fm = match[1];
+  const name = fm.match(/(?:^|\n)name:\s*(.+)/)?.[1]?.trim() ?? "";
+  const desc =
+    fm.match(/(?:^|\n)description:\s*(.+)/)?.[1]?.trim() ?? "";
+  return { name, description: desc };
+}
+
+async function getSkills(): Promise<SkillMeta[]> {
+  try {
+    const files = await readdir(SKILLS_DIR);
+    const skills: SkillMeta[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".md")) continue;
+      const content = await readFile(join(SKILLS_DIR, file), "utf-8");
+      const { name, description } = parseSkillFrontmatter(content);
+      skills.push({
+        fileName: file,
+        name: name || file.replace(/\.md$/, ""),
+        description,
+      });
+    }
+    return skills;
+  } catch {
+    return [];
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function installForClaude(skills: SkillMeta[]): Promise<number> {
+  await mkdir(CLAUDE_DIR, { recursive: true });
+  let count = 0;
+  for (const skill of skills) {
+    const src = join(SKILLS_DIR, skill.fileName);
+    const dest = join(CLAUDE_DIR, skill.fileName);
+    const content = await readFile(src, "utf-8");
+    await writeFile(dest, content, "utf-8");
+    count++;
+  }
+  return count;
+}
+
+async function installForCodex(skills: SkillMeta[]): Promise<number> {
+  let count = 0;
+  for (const skill of skills) {
+    const skillName = skill.fileName.replace(/\.md$/, "");
+    const skillDir = join(CODEX_DIR, skillName);
+    await mkdir(skillDir, { recursive: true });
+
+    const src = join(SKILLS_DIR, skill.fileName);
+    const content = await readFile(src, "utf-8");
+
+    // Codex expects SKILL.md inside a named directory
+    await writeFile(join(skillDir, "SKILL.md"), content, "utf-8");
+    count++;
+  }
+  return count;
+}
+
+// --- Commands ---
+
+const installCommand = new Command("install")
+  .description("Install Octopus skills for Claude Code and/or Codex")
+  .option("--claude", "Install only for Claude Code")
+  .option("--codex", "Install only for Codex")
+  .action(async (opts: { claude?: boolean; codex?: boolean }) => {
+    const skills = await getSkills();
+    if (skills.length === 0) {
+      error("No skills found to install.");
+      return;
+    }
+
+    const both = !opts.claude && !opts.codex;
+    let claudeCount = 0;
+    let codexCount = 0;
+
+    if (both || opts.claude) {
+      claudeCount = await installForClaude(skills);
+      success(`Installed ${claudeCount} skill(s) to ${chalk.dim(CLAUDE_DIR)}`);
+    }
+
+    if (both || opts.codex) {
+      codexCount = await installForCodex(skills);
+      success(`Installed ${codexCount} skill(s) to ${chalk.dim(CODEX_DIR)}`);
+    }
+
+    console.log();
+    for (const skill of skills) {
+      info(`${chalk.bold(skill.name)} — ${skill.description || chalk.dim("no description")}`);
+    }
+  });
+
+const listCommand = new Command("list")
+  .description("List available Octopus skills and their install status")
+  .action(async () => {
+    const skills = await getSkills();
+    if (skills.length === 0) {
+      info("No skills available.");
+      return;
+    }
+
+    const rows: string[][] = [];
+    for (const skill of skills) {
+      const claudeInstalled = await exists(join(CLAUDE_DIR, skill.fileName));
+      const codexInstalled = await exists(join(CODEX_DIR, skill.fileName.replace(/\.md$/, ""), "SKILL.md"));
+
+      rows.push([
+        chalk.bold(skill.name),
+        skill.description || chalk.dim("—"),
+        claudeInstalled ? chalk.green("yes") : chalk.dim("no"),
+        codexInstalled ? chalk.green("yes") : chalk.dim("no"),
+      ]);
+    }
+
+    table(rows, ["Skill", "Description", "Claude", "Codex"]);
+  });
+
+export const skillsCommand = new Command("skills")
+  .description("Manage Octopus skills for AI coding agents")
+  .addCommand(installCommand)
+  .addCommand(listCommand);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { repoCommand } from "./commands/repo/index.js";
 import { prCommand } from "./commands/pr/index.js";
 import { knowledgeCommand } from "./commands/knowledge/index.js";
 import { analyzeDepsCommand } from "./commands/analyze-deps.js";
+import { skillsCommand } from "./commands/skills.js";
 
 const program = new Command();
 
@@ -25,5 +26,6 @@ program.addCommand(repoCommand);
 program.addCommand(prCommand);
 program.addCommand(knowledgeCommand);
 program.addCommand(analyzeDepsCommand);
+program.addCommand(skillsCommand);
 
 program.parse();

--- a/src/skiils/octopus-fix.md
+++ b/src/skiils/octopus-fix.md
@@ -1,0 +1,120 @@
+---
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Glob, Grep
+description: Check open PRs for review comments, apply fixes, and push updates
+---
+
+# Octopus Fix
+
+Review all open PRs for pending reviews and requested changes from Octopus Review bot. Apply the necessary fixes, commit them, and push the updates.
+
+Rules:
+- Ignore false-positive feedback.
+- For each false positive, react to the comment with 👎 and explain .
+- For each valid and useful suggestion, react to the comment with 👍.
+- After fixing a valid issue, reply in the relevant review thread with a brief note describing the fix.
+- Resolve the thread/conversation after replying, if resolving is supported.
+- If thread resolution is not supported, leave a reply clearly stating that the issue has been addressed.
+
+Once all fixes are applied and pushed, post a final PR comment tagging @octopus to notify it that the updates are ready for review.
+
+## Instructions
+
+Follow these steps carefully and in order:
+
+### Step 1: Discover Open PRs
+
+1. Save the current branch name: `git branch --show-current`
+2. List open PRs authored by the current user:
+   ```
+   gh pr list --author "@me" --state open --json number,title,headRefName,reviewDecision,url
+   ```
+3. If no open PRs exist, inform the user and stop.
+4. Display the list of open PRs with their review status to the user.
+
+### Step 2: Check Reviews for Each PR
+
+For each open PR (or a specific PR if the user provided a number as argument `$ARGUMENTS`):
+
+1. Fetch review comments and review threads:
+   ```
+   gh pr view <number> --json reviews,reviewRequests,comments,title,headRefName,url
+   gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | {id, path, line, body, user: .user.login, created_at}'
+   gh api repos/{owner}/{repo}/pulls/<number>/reviews --jq '.[] | {id, state, body, user: .user.login}'
+   ```
+2. Also check for inline review comments (conversation threads):
+   ```
+   gh pr view <number> --comments --json comments
+   ```
+3. Filter for actionable feedback:
+   - Reviews with state `CHANGES_REQUESTED`
+   - Unresolved review comments (inline code suggestions, requested changes)
+   - General PR comments that contain action items
+4. Skip PRs that have no actionable feedback (state is `APPROVED` or no reviews).
+
+### Step 3: Present Review Summary
+
+Before making any changes, present a summary to the user:
+
+For each PR with actionable feedback, show:
+- PR title and number
+- Branch name
+- Reviewer(s) who requested changes
+- List of each review comment with:
+  - File path and line number (if inline)
+  - The comment text
+  - Your proposed fix or action
+
+**Ask the user to confirm** which reviews to address before proceeding.
+
+### Step 4: Apply Fixes
+
+For each confirmed PR:
+
+1. **Checkout the PR branch**:
+   ```
+   git checkout <branch-name> && git pull origin <branch-name>
+   ```
+2. **Read the relevant files** mentioned in the review comments.
+3. **Apply the requested changes**:
+   - For code suggestions: apply the suggested code change exactly
+   - For style/refactor requests: make the minimal change that addresses the feedback
+   - For bug reports: fix the bug as described
+   - For questions/clarifications: if a code change is needed, make it; otherwise note it for the summary
+4. **Stage and commit** the fixes:
+   ```
+   git add <changed-files>
+   git commit -m "$(cat <<'EOF'
+   fix: address review feedback on #<PR-number>
+
+   <bullet list of changes made in response to reviews>
+ 
+   EOF
+   )"
+   ````
+5. **Push** the changes:
+   ```
+   git push origin <branch-name>
+   ```
+
+### Step 5: Return to Original Branch
+
+After all fixes are pushed, checkout back to the branch the user was originally on.
+
+### Step 6: Report Summary
+
+Print a summary table showing:
+- PR number and title
+- Branch name
+- Number of review comments addressed
+- What was changed (brief description)
+- PR URL
+
+## Important Rules
+ 
+- **Never force-push** — always use regular `git push`.
+- **Always show the proposed fixes to the user** and get confirmation before committing.
+- **Make minimal changes** — only fix what the reviewer asked for, do not refactor surrounding code.
+- **If a review comment is unclear or ambiguous**, present it to the user and ask how to proceed rather than guessing.
+- **If the review is just a question** (no code change needed), note it in the summary but don't make unnecessary changes.
+- **If there are merge conflicts** when pulling the branch, inform the user and stop — do not attempt to resolve conflicts automatically.
+- **Preserve the existing commit history** — do not squash, rebase, or amend existing commits.


### PR DESCRIPTION
## Summary
- Add `skills` command with `install` and `list` subcommands for managing AI coding agent skills
- Support installing skills to Claude Code (`~/.claude/commands`) and Codex (`~/.agents/skills`)
- Bundle `octopus-fix` skill for reviewing open PRs and applying review fixes
- Bump version to 0.1.5

Closes #1

## Files Changed
- `src/commands/skills.ts` — New skills command implementation
- `src/skiils/octopus-fix.md` — Bundled octopus-fix skill
- `src/index.ts` — Register skills command
- `package.json` — Add `src/skiils` to files, bump version to 0.1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)