### PR TITLE
feat: add local agent command for real-time codebase search

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,44 @@ Remove a document from the knowledge base.
 octopus knowledge remove cm3x1234
 ```
 
+### `octopus skills list`
+
+List available Octopus skills and their install status for Claude Code and Codex.
+
+```
+$ octopus skills list
+
+  Skill        Description                                                        Claude  Codex
+  octopus-fix  Check open PRs for review comments, apply fixes, and push updates  yes     no
+```
+
+### `octopus skills install`
+
+Install Octopus skills for AI coding agents. By default installs for both Claude Code and Codex.
+
+```bash
+# Install for both Claude Code and Codex
+octopus skills install
+
+# Install only for Claude Code
+octopus skills install --claude
+
+# Install only for Codex
+octopus skills install --codex
+```
+
+Once installed, you can use the skills as slash commands:
+- **Claude Code**: `/octopus-fix`
+- **Codex**: Automatically available as a skill
+
+### `octopus analyze-deps <repo-url>`
+
+Analyze npm dependencies in a GitHub repository for security risks. Streams results in real-time with risk categorization.
+
+```bash
+octopus analyze-deps https://github.com/acme/backend
+```
+
 ### `octopus usage`
 
 Show your organization's monthly usage, spend, and credit balance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octp/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "CLI tool for Octopus — AI-powered PR review and codebase intelligence",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/agent/claude-searcher.ts
+++ b/src/commands/agent/claude-searcher.ts
@@ -1,0 +1,52 @@
+import { execSync } from "node:child_process";
+
+const MAX_SUMMARY_SIZE = 15 * 1024; // 15KB
+
+/**
+ * Check if the Claude CLI is available.
+ */
+export function hasClaudeCli(): boolean {
+  try {
+    execSync("claude --version", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run a search query using Claude CLI.
+ * Shells out to `claude -p` in the repo directory.
+ */
+export async function claudeSearch(
+  query: string,
+  repoDir: string,
+  timeoutMs = 25_000,
+): Promise<string> {
+  const prompt = `Search this codebase for information relevant to the following question. Return the most relevant code snippets with file paths and line numbers. Be concise and focus on the most important findings.\n\nQuestion: ${query}`;
+
+  try {
+    const result = execSync(
+      `claude -p ${JSON.stringify(prompt)}`,
+      {
+        cwd: repoDir,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        maxBuffer: 2 * 1024 * 1024, // 2MB
+        timeout: timeoutMs,
+      },
+    );
+
+    const summary = result.trim();
+    return summary.length > MAX_SUMMARY_SIZE
+      ? summary.slice(0, MAX_SUMMARY_SIZE)
+      : summary;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    throw new Error(`Claude CLI search failed: ${message}`);
+  }
+}

--- a/src/commands/agent/index.ts
+++ b/src/commands/agent/index.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+import { watchCommand } from "./watch.js";
+import { startCommand } from "./start.js";
+
+export const agentCommand = new Command("agent")
+  .description("Local agent for real-time codebase search")
+  .addCommand(watchCommand)
+  .addCommand(startCommand);

--- a/src/commands/agent/searcher.ts
+++ b/src/commands/agent/searcher.ts
@@ -1,0 +1,333 @@
+import { execSync } from "node:child_process";
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join, extname, relative } from "node:path";
+
+interface SearchResult {
+  file: string;
+  line: number;
+  content: string;
+}
+
+interface SearchResponse {
+  results: SearchResult[];
+  summary: string;
+}
+
+const MAX_SUMMARY_SIZE = 15 * 1024; // 15KB
+
+/**
+ * Extract likely search keywords from a natural language query.
+ */
+function extractKeywords(query: string): string[] {
+  // Remove common filler words
+  const stopWords = new Set([
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "can", "shall", "to", "of", "in", "for",
+    "on", "with", "at", "by", "from", "as", "into", "through", "during",
+    "before", "after", "above", "below", "between", "this", "that", "these",
+    "those", "i", "you", "he", "she", "it", "we", "they", "what", "which",
+    "who", "when", "where", "why", "how", "all", "each", "every", "both",
+    "few", "more", "most", "other", "some", "such", "no", "not", "only",
+    "same", "so", "than", "too", "very", "just", "but", "and", "or",
+    "if", "because", "about", "find", "search", "show", "me", "tell",
+    "explain", "code", "function", "file", "used", "using", "called",
+    "where", "does", "defined", "nerede", "nasil", "ne", "bu", "bir",
+    "ve", "ile", "icin", "mi", "var", "yok",
+  ]);
+
+  // Split on word boundaries and filter
+  const words = query
+    .replace(/[^\w\s.-]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 2 && !stopWords.has(w.toLowerCase()));
+
+  // Also extract quoted strings as exact phrases
+  const quoted = query.match(/"([^"]+)"|'([^']+)'/g);
+  if (quoted) {
+    words.push(...quoted.map((q) => q.replace(/["']/g, "")));
+  }
+
+  // Extract camelCase/PascalCase identifiers (likely code references)
+  const identifiers = query.match(/[A-Z][a-z]+[A-Z]\w+|[a-z]+[A-Z]\w+/g);
+  if (identifiers) {
+    words.unshift(...identifiers); // prioritize these
+  }
+
+  // Deduplicate
+  return [...new Set(words)].slice(0, 10);
+}
+
+/**
+ * Run ripgrep with a pattern in a directory.
+ */
+function ripgrep(pattern: string, dir: string, maxResults = 20): SearchResult[] {
+  try {
+    const rgCmd = `rg --no-heading --line-number --max-count 5 --max-columns 200 --type-add 'code:*.{ts,tsx,js,jsx,py,go,rs,java,rb,php,c,cpp,h,cs,swift,kt,scala,vue,svelte}' --type code --glob '!node_modules' --glob '!dist' --glob '!.git' --glob '!*.lock' --glob '!*.min.*' -- ${JSON.stringify(pattern)} ${JSON.stringify(dir)}`;
+    const output = execSync(rgCmd, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024,
+      timeout: 5000,
+    });
+
+    return output
+      .split("\n")
+      .filter(Boolean)
+      .slice(0, maxResults)
+      .map((line) => {
+        // Format: filepath:line:content
+        const match = line.match(/^(.+?):(\d+):(.*)$/);
+        if (!match) return null;
+        const filePath = match[1].startsWith(dir)
+          ? match[1].slice(dir.length + 1)
+          : match[1];
+        return {
+          file: filePath,
+          line: parseInt(match[2], 10),
+          content: match[3].trim(),
+        };
+      })
+      .filter((r): r is SearchResult => r !== null);
+  } catch {
+    return [];
+  }
+}
+
+const CODE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+  ".py", ".go", ".rs", ".java", ".rb", ".php",
+  ".c", ".cpp", ".h", ".cs", ".swift", ".kt",
+  ".scala", ".vue", ".svelte",
+]);
+
+const SKIP_DIRS = new Set([
+  "node_modules", "dist", ".git", ".next", "build",
+  "out", "coverage", "__pycache__", ".turbo", "vendor",
+]);
+
+/**
+ * Pure Node.js fallback search — works on all platforms (macOS, Linux, Windows).
+ * Walks the directory tree, reads code files, and matches lines.
+ */
+function nodeSearch(pattern: string, dir: string, maxResults = 20): SearchResult[] {
+  const results: SearchResult[] = [];
+  const regex = new RegExp(escapeRegex(pattern), "i");
+
+  function walk(currentDir: string): void {
+    if (results.length >= maxResults) return;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(currentDir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (results.length >= maxResults) return;
+      if (SKIP_DIRS.has(entry) || entry.startsWith(".")) continue;
+
+      const fullPath = join(currentDir, entry);
+      let stat;
+      try {
+        stat = statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (stat.isFile() && CODE_EXTENSIONS.has(extname(entry))) {
+        // Skip large files (>200KB)
+        if (stat.size > 200_000) continue;
+
+        try {
+          const content = readFileSync(fullPath, "utf-8");
+          const lines = content.split("\n");
+          let matchCount = 0;
+
+          for (let i = 0; i < lines.length; i++) {
+            if (matchCount >= 5) break;
+            if (regex.test(lines[i])) {
+              results.push({
+                file: relative(dir, fullPath),
+                line: i + 1,
+                content: lines[i].trim().slice(0, 200),
+              });
+              matchCount++;
+              if (results.length >= maxResults) return;
+            }
+          }
+        } catch {
+          // Skip unreadable files
+        }
+      }
+    }
+  }
+
+  walk(dir);
+  return results;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Check if ripgrep is available.
+ */
+function hasRipgrep(): boolean {
+  try {
+    execSync("rg --version", { stdio: ["pipe", "pipe", "pipe"] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a file and return content with line numbers.
+ */
+function readFile(filePath: string, repoDir: string): string | null {
+  const fullPath = join(repoDir, filePath);
+  if (!existsSync(fullPath)) return null;
+  try {
+    const content = readFileSync(fullPath, "utf-8");
+    return content
+      .split("\n")
+      .map((line, i) => `${i + 1}: ${line}`)
+      .join("\n");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Perform a semantic search using keyword extraction + parallel ripgrep.
+ */
+export async function semanticSearch(query: string, repoDir: string): Promise<SearchResponse> {
+  const keywords = extractKeywords(query);
+  const useRg = hasRipgrep();
+  const searchFn = useRg ? ripgrep : nodeSearch;
+
+  // Run searches for all keywords in parallel
+  const allResults: SearchResult[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const keyword of keywords) {
+    const results = searchFn(keyword, repoDir, 15);
+    for (const r of results) {
+      const key = `${r.file}:${r.line}`;
+      if (!seenKeys.has(key)) {
+        seenKeys.add(key);
+        allResults.push(r);
+      }
+    }
+  }
+
+  // Score results — files matching more keywords rank higher
+  const fileScores = new Map<string, number>();
+  for (const r of allResults) {
+    fileScores.set(r.file, (fileScores.get(r.file) ?? 0) + 1);
+  }
+
+  // Sort by file frequency (multi-keyword matches first), then by line number
+  allResults.sort((a, b) => {
+    const scoreA = fileScores.get(a.file) ?? 0;
+    const scoreB = fileScores.get(b.file) ?? 0;
+    if (scoreB !== scoreA) return scoreB - scoreA;
+    return a.line - b.line;
+  });
+
+  // Build summary
+  const topResults = allResults.slice(0, 30);
+  const summary = buildSummary(topResults, keywords, repoDir);
+
+  return { results: topResults, summary };
+}
+
+/**
+ * Perform a direct grep search.
+ */
+export async function grepSearch(pattern: string, repoDir: string): Promise<SearchResponse> {
+  const useRg = hasRipgrep();
+  const searchFn = useRg ? ripgrep : nodeSearch;
+  const results = searchFn(pattern, repoDir, 30);
+  const summary = buildSummary(results, [pattern], repoDir);
+  return { results, summary };
+}
+
+/**
+ * Read specific files.
+ */
+export async function fileReadSearch(filePaths: string[], repoDir: string): Promise<SearchResponse> {
+  const results: SearchResult[] = [];
+  const summaryParts: string[] = [];
+
+  for (const fp of filePaths.slice(0, 5)) {
+    const content = readFile(fp, repoDir);
+    if (content) {
+      summaryParts.push(`### ${fp}\n\`\`\`\n${content.slice(0, 3000)}\n\`\`\``);
+      // Add a synthetic result for each file
+      results.push({ file: fp, line: 1, content: `[file content: ${content.split("\n").length} lines]` });
+    }
+  }
+
+  const summary = summaryParts.join("\n\n").slice(0, MAX_SUMMARY_SIZE);
+  return { results, summary };
+}
+
+/**
+ * Build a context summary from search results.
+ * Groups results by file and includes surrounding context.
+ */
+function buildSummary(results: SearchResult[], keywords: string[], repoDir: string): string {
+  if (results.length === 0) {
+    return `No results found for: ${keywords.join(", ")}`;
+  }
+
+  // Group by file
+  const byFile = new Map<string, SearchResult[]>();
+  for (const r of results) {
+    const existing = byFile.get(r.file) ?? [];
+    existing.push(r);
+    byFile.set(r.file, existing);
+  }
+
+  const parts: string[] = [`Search results for: ${keywords.join(", ")}\n`];
+
+  for (const [file, fileResults] of byFile) {
+    parts.push(`### ${file}`);
+
+    // Try to read surrounding lines for context
+    const fullPath = join(repoDir, file);
+    let fileLines: string[] | null = null;
+    try {
+      if (existsSync(fullPath)) {
+        fileLines = readFileSync(fullPath, "utf-8").split("\n");
+      }
+    } catch {}
+
+    for (const r of fileResults.slice(0, 5)) {
+      if (fileLines) {
+        // Show 2 lines before and after for context
+        const start = Math.max(0, r.line - 3);
+        const end = Math.min(fileLines.length, r.line + 2);
+        const contextLines = fileLines
+          .slice(start, end)
+          .map((l, i) => `${start + i + 1}: ${l}`)
+          .join("\n");
+        parts.push(`\`\`\`\n${contextLines}\n\`\`\``);
+      } else {
+        parts.push(`L${r.line}: ${r.content}`);
+      }
+    }
+    parts.push("");
+  }
+
+  const summary = parts.join("\n");
+  return summary.length > MAX_SUMMARY_SIZE
+    ? summary.slice(0, MAX_SUMMARY_SIZE)
+    : summary;
+}

--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -1,0 +1,292 @@
+import { Command } from "commander";
+import { hostname } from "node:os";
+import { existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import chalk from "chalk";
+import { apiPost, apiGet } from "../../lib/api-client.js";
+import { getApiUrl, getApiToken } from "../../lib/config-store.js";
+import { success, error, warn, info } from "../../lib/output.js";
+import { loadWatchConfig, type WatchEntry } from "./watch.js";
+import { semanticSearch, grepSearch, fileReadSearch } from "./searcher.js";
+import { hasClaudeCli, claudeSearch } from "./claude-searcher.js";
+
+interface RegisterResponse {
+  agentId: string;
+  channel: string;
+  orgId: string;
+}
+
+interface SearchTask {
+  id: string;
+  query: string;
+  searchType: string;
+  params: Record<string, unknown>;
+  repoFullName: string;
+  timeoutMs: number;
+}
+
+function parseGitRemote(url: string): string | null {
+  const sshMatch = url.match(/git@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+  const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (httpsMatch) return httpsMatch[1];
+  return null;
+}
+
+function getGitRemoteUrl(dirPath: string): string | null {
+  try {
+    return execSync("git remote get-url origin", {
+      cwd: dirPath,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve watched directories to repo mappings.
+ */
+function resolveWatchedRepos(): Map<string, string> {
+  const config = loadWatchConfig();
+  const repoMap = new Map<string, string>(); // repoFullName -> localPath
+
+  for (const entry of config.entries) {
+    if (!existsSync(entry.path)) {
+      warn(`Skipping ${entry.path} — directory not found`);
+      continue;
+    }
+
+    const remoteUrl = getGitRemoteUrl(entry.path);
+    if (!remoteUrl) {
+      warn(`Skipping ${entry.path} — no git remote`);
+      continue;
+    }
+
+    const fullName = parseGitRemote(remoteUrl);
+    if (!fullName) {
+      warn(`Skipping ${entry.path} — could not parse remote: ${remoteUrl}`);
+      continue;
+    }
+
+    repoMap.set(fullName, entry.path);
+  }
+
+  return repoMap;
+}
+
+export const startCommand = new Command("start")
+  .description("Start the local agent daemon")
+  .option("--with-claude", "Enable Claude CLI for deep semantic search")
+  .option("--verbose", "Show detailed logs")
+  .action(async (opts: { withClaude?: boolean; verbose?: boolean }) => {
+    const token = getApiToken();
+    if (!token) {
+      error("Not logged in. Run 'octopus login' first.");
+      process.exit(1);
+    }
+
+    // Resolve watched repos
+    const repoMap = resolveWatchedRepos();
+    if (repoMap.size === 0) {
+      error("No watched repos found. Run 'octopus agent watch' in a repo directory first.");
+      process.exit(1);
+    }
+
+    const repoFullNames = [...repoMap.keys()];
+    info(`Found ${repoMap.size} watched repo(s):`);
+    for (const [name, path] of repoMap) {
+      console.log(`  ${chalk.cyan(name)} → ${path}`);
+    }
+
+    // Check Claude CLI availability
+    const claudeAvailable = opts.withClaude ? hasClaudeCli() : false;
+    if (opts.withClaude && !claudeAvailable) {
+      warn("Claude CLI not found. Falling back to ripgrep mode.");
+    }
+
+    const capabilities = ["code-search"]; // ripgrep or Node.js fallback
+    if (claudeAvailable) capabilities.push("claude-cli");
+
+    const agentName = `${hostname()}-${process.pid}`;
+
+    // Register with server
+    let agentId: string;
+    let orgId: string;
+    try {
+      const res = await apiPost<RegisterResponse>("/api/agent/register", {
+        name: agentName,
+        repoFullNames,
+        capabilities,
+        machineInfo: {
+          os: process.platform,
+          hostname: hostname(),
+          nodeVersion: process.version,
+        },
+      });
+      agentId = res.agentId;
+      orgId = res.orgId;
+      success(`Registered as "${agentName}" (${capabilities.join(", ")})`);
+    } catch (err) {
+      error(`Failed to register: ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+
+    // Heartbeat interval
+    const heartbeatInterval = setInterval(async () => {
+      try {
+        // Re-scan repos in case they changed
+        const freshMap = resolveWatchedRepos();
+        const freshNames = [...freshMap.keys()];
+        // Update our local map
+        for (const [name, path] of freshMap) {
+          repoMap.set(name, path);
+        }
+        await apiPost("/api/agent/heartbeat", {
+          agentId,
+          repoFullNames: freshNames,
+        });
+        if (opts.verbose) {
+          info(`Heartbeat sent (${freshNames.length} repos)`);
+        }
+      } catch (err) {
+        if (opts.verbose) {
+          warn(`Heartbeat failed: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+    }, 30_000);
+
+    // Task polling interval (fallback for missed Pubby signals)
+    const pollInterval = setInterval(async () => {
+      try {
+        const res = await apiGet<{ tasks: SearchTask[] }>(
+          `/api/agent/tasks?agentId=${agentId}`,
+        );
+        for (const task of res.tasks) {
+          handleTask(task, repoMap, agentId, claudeAvailable, opts.verbose ?? false);
+        }
+      } catch (err) {
+        if (opts.verbose) {
+          warn(`Poll failed: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+    }, 5_000);
+
+    // Graceful shutdown
+    const cleanup = async () => {
+      console.log("\n");
+      info("Shutting down...");
+      clearInterval(heartbeatInterval);
+      clearInterval(pollInterval);
+
+      try {
+        await apiPost("/api/agent/disconnect", { agentId });
+        success("Disconnected.");
+      } catch {}
+
+      process.exit(0);
+    };
+
+    process.on("SIGINT", cleanup);
+    process.on("SIGTERM", cleanup);
+
+    console.log("");
+    success(`Agent running. Listening for search requests...`);
+    info(`Press Ctrl+C to stop.\n`);
+  });
+
+/**
+ * Handle a single search task — claim, execute, submit result.
+ */
+async function handleTask(
+  task: SearchTask,
+  repoMap: Map<string, string>,
+  agentId: string,
+  claudeAvailable: boolean,
+  verbose: boolean,
+): Promise<void> {
+  const repoDir = repoMap.get(task.repoFullName);
+  if (!repoDir) return;
+
+  // Claim the task
+  try {
+    await apiPost(`/api/agent/tasks/${task.id}/claim`, { agentId });
+  } catch {
+    // Already claimed by another agent
+    return;
+  }
+
+  if (verbose) {
+    info(`Claimed task ${task.id}: "${task.query}" (${task.searchType}) in ${task.repoFullName}`);
+  }
+
+  try {
+    let resultSummary: string;
+
+    switch (task.searchType) {
+      case "claude": {
+        if (claudeAvailable) {
+          try {
+            resultSummary = await claudeSearch(task.query, repoDir, task.timeoutMs - 2000);
+          } catch {
+            // Fall back to semantic search
+            if (verbose) warn("Claude CLI failed, falling back to ripgrep");
+            const { summary } = await semanticSearch(task.query, repoDir);
+            resultSummary = summary;
+          }
+        } else {
+          const { summary } = await semanticSearch(task.query, repoDir);
+          resultSummary = summary;
+        }
+        break;
+      }
+
+      case "grep": {
+        const pattern = (task.params as { pattern?: string }).pattern ?? task.query;
+        const { summary } = await grepSearch(pattern, repoDir);
+        resultSummary = summary;
+        break;
+      }
+
+      case "file-read": {
+        const filePaths = (task.params as { filePaths?: string[] }).filePaths ?? [];
+        const { summary } = await fileReadSearch(filePaths, repoDir);
+        resultSummary = summary;
+        break;
+      }
+
+      case "semantic":
+      default: {
+        const { summary } = await semanticSearch(task.query, repoDir);
+        resultSummary = summary;
+        break;
+      }
+    }
+
+    // Submit results
+    await apiPost(`/api/agent/tasks/${task.id}/result`, {
+      results: [],
+      resultSummary,
+    });
+
+    if (verbose) {
+      success(`Completed task ${task.id} (${resultSummary.length} chars)`);
+    } else {
+      console.log(
+        `${chalk.green("✓")} Searched "${task.query.slice(0, 50)}${task.query.length > 50 ? "..." : ""}" in ${chalk.cyan(task.repoFullName)}`,
+      );
+    }
+  } catch (err) {
+    // Submit error
+    try {
+      await apiPost(`/api/agent/tasks/${task.id}/result`, {
+        errorMessage: err instanceof Error ? err.message : "Unknown error",
+      });
+    } catch {}
+
+    if (verbose) {
+      error(`Task ${task.id} failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+}

--- a/src/commands/agent/watch.ts
+++ b/src/commands/agent/watch.ts
@@ -1,0 +1,146 @@
+import { Command } from "commander";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
+import chalk from "chalk";
+import { success, error, warn, info, heading, table } from "../../lib/output.js";
+
+const CONFIG_DIR = join(homedir(), ".octopus");
+const WATCH_FILE = join(CONFIG_DIR, "agent-watch.json");
+
+interface WatchEntry {
+  path: string;
+  remoteUrl: string;
+  repoFullName: string;
+  addedAt: string;
+}
+
+interface WatchConfig {
+  entries: WatchEntry[];
+}
+
+function loadWatchConfig(): WatchConfig {
+  try {
+    const data = readFileSync(WATCH_FILE, "utf-8");
+    return JSON.parse(data);
+  } catch {
+    return { entries: [] };
+  }
+}
+
+function saveWatchConfig(config: WatchConfig): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  }
+  writeFileSync(WATCH_FILE, JSON.stringify(config, null, 2));
+}
+
+function getGitRemoteUrl(dirPath: string): string | null {
+  try {
+    return execSync("git remote get-url origin", {
+      cwd: dirPath,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseGitRemote(url: string): string | null {
+  // SSH: git@github.com:owner/repo.git
+  const sshMatch = url.match(/git@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+
+  // HTTPS: https://github.com/owner/repo.git
+  const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (httpsMatch) return httpsMatch[1];
+
+  return null;
+}
+
+export { loadWatchConfig, type WatchEntry };
+
+export const watchCommand = new Command("watch")
+  .description("Manage watched directories for local agent")
+  .argument("[path]", "Directory to watch (defaults to current directory)")
+  .option("--list", "List all watched directories")
+  .option("--remove", "Remove directory from watch list")
+  .action(async (pathArg: string | undefined, opts: { list?: boolean; remove?: boolean }) => {
+    if (opts.list) {
+      const config = loadWatchConfig();
+      if (config.entries.length === 0) {
+        info("No watched directories. Run 'octopus agent watch' in a repo directory to add one.");
+        return;
+      }
+
+      heading("Watched Directories");
+      const rows = config.entries.map((entry) => {
+        const exists = existsSync(entry.path);
+        const status = exists ? chalk.green("ok") : chalk.red("missing");
+        return [entry.path, chalk.cyan(entry.repoFullName), status];
+      });
+      table(rows, ["Path", "Repository", "Status"]);
+      return;
+    }
+
+    const targetPath = resolve(pathArg ?? ".");
+
+    if (opts.remove) {
+      const config = loadWatchConfig();
+      const before = config.entries.length;
+      config.entries = config.entries.filter((e) => e.path !== targetPath);
+      if (config.entries.length === before) {
+        warn(`${targetPath} is not in the watch list.`);
+        return;
+      }
+      saveWatchConfig(config);
+      success(`Removed ${targetPath} from watch list.`);
+      return;
+    }
+
+    // Add directory to watch list
+    if (!existsSync(targetPath)) {
+      error(`Directory not found: ${targetPath}`);
+      process.exit(1);
+    }
+
+    const remoteUrl = getGitRemoteUrl(targetPath);
+    if (!remoteUrl) {
+      error(`No git remote found in ${targetPath}. Is this a git repository?`);
+      process.exit(1);
+    }
+
+    const repoFullName = parseGitRemote(remoteUrl);
+    if (!repoFullName) {
+      error(`Could not parse git remote URL: ${remoteUrl}`);
+      process.exit(1);
+    }
+
+    const config = loadWatchConfig();
+
+    // Check for duplicates
+    const existing = config.entries.find((e) => e.path === targetPath);
+    if (existing) {
+      if (existing.repoFullName === repoFullName) {
+        info(`${targetPath} is already watched as ${chalk.cyan(repoFullName)}.`);
+        return;
+      }
+      // Update remote if changed
+      existing.remoteUrl = remoteUrl;
+      existing.repoFullName = repoFullName;
+      saveWatchConfig(config);
+      success(`Updated ${targetPath} → ${chalk.cyan(repoFullName)} (via git remote)`);
+      return;
+    }
+
+    config.entries.push({
+      path: targetPath,
+      remoteUrl,
+      repoFullName,
+      addedAt: new Date().toISOString(),
+    });
+    saveWatchConfig(config);
+    success(`Added ${targetPath} → ${chalk.cyan(repoFullName)} (via git remote)`);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { prCommand } from "./commands/pr/index.js";
 import { knowledgeCommand } from "./commands/knowledge/index.js";
 import { analyzeDepsCommand } from "./commands/analyze-deps.js";
 import { skillsCommand } from "./commands/skills.js";
+import { agentCommand } from "./commands/agent/index.js";
 
 const program = new Command();
 
@@ -27,5 +28,6 @@ program.addCommand(prCommand);
 program.addCommand(knowledgeCommand);
 program.addCommand(analyzeDepsCommand);
 program.addCommand(skillsCommand);
+program.addCommand(agentCommand);
 
 program.parse();


### PR DESCRIPTION
## Summary
- Add `octopus agent` command with `watch` and `start` subcommands for local real-time codebase search
- Support multiple search backends: ripgrep, Node.js fallback, and optional Claude CLI
- Semantic search with keyword extraction, multi-keyword ranking, and contextual results
- Update README with documentation for skills, analyze-deps commands
- Bump version to 0.1.6

Closes #3

## Files Changed
- `src/commands/agent/index.ts` — agent command entry point
- `src/commands/agent/start.ts` — agent daemon with registration, heartbeat, task handling
- `src/commands/agent/watch.ts` — watch list management
- `src/commands/agent/searcher.ts` — ripgrep + Node.js search backends
- `src/commands/agent/claude-searcher.ts` — Claude CLI search integration
- `src/index.ts` — register agent command
- `README.md` — documentation updates
- `package.json` — version bump to 0.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)