### PR TITLE
feat: agent background mode and auto-start

### DIFF
--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { hostname } from "node:os";
-import { existsSync } from "node:fs";
+import { hostname, homedir } from "node:os";
+import { existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { execSync, spawn } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -97,6 +97,11 @@ export const startCommand = new Command("start")
     // Default: background mode — spawn detached child and exit
     if (!runInForeground) {
       const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
+      if (!existsSync(binPath)) {
+        error(`Could not locate agent binary at: ${binPath}`);
+        process.exit(1);
+      }
+
       const args = [binPath, "agent", "start", "--foreground"];
       if (opts.withClaude) args.push("--with-claude");
 
@@ -104,10 +109,22 @@ export const startCommand = new Command("start")
         detached: true,
         stdio: "ignore",
       });
+
+      child.on("error", (err) => {
+        error(`Failed to start background agent: ${err.message}`);
+        process.exit(1);
+      });
+
       child.unref();
 
+      // Write PID file for manageability
+      const pidDir = join(homedir(), ".octopus");
+      mkdirSync(pidDir, { recursive: true });
+      const pidFile = join(pidDir, "agent.pid");
+      writeFileSync(pidFile, String(child.pid));
+
       success(`Agent started in background (PID: ${child.pid})`);
-      info("Use 'octopus agent status' or 'kill' to manage the process.");
+      info(`PID saved to ${pidFile}. To stop: kill $(cat ${pidFile})`);
       process.exit(0);
     }
 

--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
 import { hostname } from "node:os";
 import { existsSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import { apiPost, apiGet } from "../../lib/api-client.js";
 import { getApiUrl, getApiToken } from "../../lib/config-store.js";
@@ -9,6 +11,8 @@ import { success, error, warn, info } from "../../lib/output.js";
 import { loadWatchConfig, type WatchEntry } from "./watch.js";
 import { semanticSearch, grepSearch, fileReadSearch } from "./searcher.js";
 import { hasClaudeCli, claudeSearch } from "./claude-searcher.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 interface RegisterResponse {
   agentId: string;
@@ -79,12 +83,32 @@ function resolveWatchedRepos(): Map<string, string> {
 export const startCommand = new Command("start")
   .description("Start the local agent daemon")
   .option("--with-claude", "Enable Claude CLI for deep semantic search")
-  .option("--verbose", "Show detailed logs")
-  .action(async (opts: { withClaude?: boolean; verbose?: boolean }) => {
+  .option("--verbose", "Run in foreground with detailed logs")
+  .option("--foreground", "Run in foreground (without verbose logs)")
+  .action(async (opts: { withClaude?: boolean; verbose?: boolean; foreground?: boolean }) => {
     const token = getApiToken();
     if (!token) {
       error("Not logged in. Run 'octopus login' first.");
       process.exit(1);
+    }
+
+    const runInForeground = opts.verbose || opts.foreground;
+
+    // Default: background mode — spawn detached child and exit
+    if (!runInForeground) {
+      const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
+      const args = [binPath, "agent", "start", "--foreground"];
+      if (opts.withClaude) args.push("--with-claude");
+
+      const child = spawn(process.execPath, args, {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+
+      success(`Agent started in background (PID: ${child.pid})`);
+      info("Use 'octopus agent status' or 'kill' to manage the process.");
+      process.exit(0);
     }
 
     // Resolve watched repos
@@ -133,6 +157,8 @@ export const startCommand = new Command("start")
       process.exit(1);
     }
 
+    const verbose = opts.verbose ?? false;
+
     // Heartbeat interval
     const heartbeatInterval = setInterval(async () => {
       try {
@@ -147,11 +173,11 @@ export const startCommand = new Command("start")
           agentId,
           repoFullNames: freshNames,
         });
-        if (opts.verbose) {
+        if (verbose) {
           info(`Heartbeat sent (${freshNames.length} repos)`);
         }
       } catch (err) {
-        if (opts.verbose) {
+        if (verbose) {
           warn(`Heartbeat failed: ${err instanceof Error ? err.message : err}`);
         }
       }
@@ -163,15 +189,18 @@ export const startCommand = new Command("start")
         const res = await apiGet<{ tasks: SearchTask[] }>(
           `/api/agent/tasks?agentId=${agentId}`,
         );
+        if (verbose && res.tasks.length > 0) {
+          info(`Received ${res.tasks.length} task(s)`);
+        }
         for (const task of res.tasks) {
-          handleTask(task, repoMap, agentId, claudeAvailable, opts.verbose ?? false);
+          handleTask(task, repoMap, agentId, claudeAvailable, verbose);
         }
       } catch (err) {
-        if (opts.verbose) {
+        if (verbose) {
           warn(`Poll failed: ${err instanceof Error ? err.message : err}`);
         }
       }
-    }, 5_000);
+    }, 2_000);
 
     // Graceful shutdown
     const cleanup = async () => {
@@ -193,7 +222,15 @@ export const startCommand = new Command("start")
 
     console.log("");
     success(`Agent running. Listening for search requests...`);
-    info(`Press Ctrl+C to stop.\n`);
+    if (verbose) {
+      info("Verbose mode enabled — showing all activity logs.");
+      info(`Agent ID: ${agentId}`);
+      info(`Repos: ${repoFullNames.join(", ")}`);
+      info(`Polling every 2s, heartbeat every 30s`);
+      info(`Press Ctrl+C to stop.\n`);
+    } else {
+      info(`Press Ctrl+C to stop.\n`);
+    }
   });
 
 /**

--- a/src/commands/agent/watch.ts
+++ b/src/commands/agent/watch.ts
@@ -1,10 +1,13 @@
 import { Command } from "commander";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { execSync } from "node:child_process";
-import { resolve, join } from "node:path";
+import { execSync, spawn } from "node:child_process";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import chalk from "chalk";
 import { success, error, warn, info, heading, table } from "../../lib/output.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const CONFIG_DIR = join(homedir(), ".octopus");
 const WATCH_FILE = join(CONFIG_DIR, "agent-watch.json");
@@ -67,7 +70,9 @@ export const watchCommand = new Command("watch")
   .argument("[path]", "Directory to watch (defaults to current directory)")
   .option("--list", "List all watched directories")
   .option("--remove", "Remove directory from watch list")
-  .action(async (pathArg: string | undefined, opts: { list?: boolean; remove?: boolean }) => {
+  .option("--no-start", "Don't auto-start the agent after adding")
+  .option("--verbose", "Start agent in foreground with detailed logs")
+  .action(async (pathArg: string | undefined, opts: { list?: boolean; remove?: boolean; start?: boolean; verbose?: boolean }) => {
     if (opts.list) {
       const config = loadWatchConfig();
       if (config.entries.length === 0) {
@@ -143,4 +148,17 @@ export const watchCommand = new Command("watch")
     });
     saveWatchConfig(config);
     success(`Added ${targetPath} → ${chalk.cyan(repoFullName)} (via git remote)`);
+
+    if (opts.start !== false) {
+      info("Starting agent...\n");
+      const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
+      const args = [binPath, "agent", "start"];
+      if (opts.verbose) args.push("--verbose");
+
+      const child = spawn(process.execPath, args, {
+        stdio: "inherit",
+      });
+      child.on("close", (code) => process.exit(code ?? 0));
+      await new Promise(() => {});
+    }
   });

--- a/src/commands/agent/watch.ts
+++ b/src/commands/agent/watch.ts
@@ -158,7 +158,11 @@ export const watchCommand = new Command("watch")
       const child = spawn(process.execPath, args, {
         stdio: "inherit",
       });
-      child.on("close", (code) => process.exit(code ?? 0));
-      await new Promise(() => {});
+      await new Promise<void>((resolve) => {
+        child.on("close", (code) => {
+          process.exit(code ?? 0);
+          resolve();
+        });
+      });
     }
   });


### PR DESCRIPTION
## Summary
- Agent starts as detached background process by default
- Add `--foreground` and `--verbose` flags for foreground operation
- `watch` command auto-starts agent after adding a repo (`--no-start` to skip)
- Reduce polling interval from 5s to 2s

Closes #8

## Files Changed
- `src/commands/agent/start.ts`
- `src/commands/agent/watch.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)