### PR TITLE
feat: add cross-platform install scripts for curl-based installation

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,5 @@
-# Octopus CLI installer for Windows
+#Requires -Version 6.0
+# Octopus CLI installer for Windows (requires PowerShell 6+ / PowerShell Core)
 # Usage: irm https://octopus-review.ai/install.ps1 | iex
 $ErrorActionPreference = "Stop"
 
@@ -42,7 +43,7 @@ function Get-LatestVersion {
 # ─── Download & Install ────────────────────────────────────────────────────
 
 function Install-Octopus {
-    $arch = Get-Arch
+    param($arch)
     $version = Get-LatestVersion
 
     $artifact = "$BINARY_NAME-windows-$arch.exe"
@@ -61,6 +62,24 @@ function Install-Octopus {
         Invoke-WebRequest -Uri $downloadUrl -OutFile $destination -UseBasicParsing
     } catch {
         Write-Err "Download failed. Check if a release exists for windows-$arch. Error: $_"
+    }
+
+    # Verify SHA256 checksum if checksums.txt is available
+    $checksumsUrl = "https://github.com/$GITHUB_REPO/releases/download/$version/checksums.txt"
+    try {
+        $checksums = Invoke-RestMethod -Uri $checksumsUrl -Headers @{ "User-Agent" = "octopus-installer" }
+        $expectedLine = $checksums -split "`n" | Where-Object { $_ -match $artifact }
+        if ($expectedLine) {
+            $expectedSha = ($expectedLine -split "\s+")[0]
+            $actualSha = (Get-FileHash -Path $destination -Algorithm SHA256).Hash.ToLower()
+            if ($expectedSha -ne $actualSha) {
+                Remove-Item $destination -Force
+                Write-Err "Checksum mismatch! Expected $expectedSha, got $actualSha. Aborting."
+            }
+            Write-Info "Checksum verified."
+        }
+    } catch {
+        Write-Warn "No checksums.txt found for this release — skipping integrity check."
     }
 
     Write-Success "Installed $BINARY_NAME to $destination"
@@ -101,7 +120,7 @@ Write-Host ""
 $arch = Get-Arch
 Write-Info "Detected platform: windows-$arch"
 
-Install-Octopus
+Install-Octopus -arch $arch
 Prompt-InstallSkills
 
 Write-Host ""

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,110 @@
+# Octopus CLI installer for Windows
+# Usage: irm https://octopus-review.ai/install.ps1 | iex
+$ErrorActionPreference = "Stop"
+
+$GITHUB_REPO = "octopusreview/octopus-cli"
+$BINARY_NAME = "octopus"
+$INSTALL_DIR = "$env:USERPROFILE\.octopus\bin"
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+function Write-Info    { param($msg) Write-Host $msg -ForegroundColor Cyan }
+function Write-Success { param($msg) Write-Host $msg -ForegroundColor Green }
+function Write-Warn    { param($msg) Write-Host $msg -ForegroundColor Yellow }
+function Write-Err     { param($msg) Write-Host "error: $msg" -ForegroundColor Red; exit 1 }
+
+# ─── Detect Architecture ───────────────────────────────────────────────────
+
+function Get-Arch {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch) {
+        "X64"   { return "x64" }
+        "Arm64" { return "arm64" }
+        default { Write-Err "Unsupported architecture: $arch" }
+    }
+}
+
+# ─── Get Latest Release ────────────────────────────────────────────────────
+
+function Get-LatestVersion {
+    $url = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+    try {
+        $release = Invoke-RestMethod -Uri $url -Headers @{ "User-Agent" = "octopus-installer" }
+        $version = $release.tag_name
+        if (-not $version) { Write-Err "Could not determine latest version." }
+        Write-Info "Latest version: $version"
+        return $version
+    } catch {
+        Write-Err "Failed to fetch latest release: $_"
+    }
+}
+
+# ─── Download & Install ────────────────────────────────────────────────────
+
+function Install-Octopus {
+    $arch = Get-Arch
+    $version = Get-LatestVersion
+
+    $artifact = "$BINARY_NAME-windows-$arch.exe"
+    $downloadUrl = "https://github.com/$GITHUB_REPO/releases/download/$version/$artifact"
+
+    Write-Info "Downloading $artifact..."
+
+    # Ensure install directory exists
+    if (-not (Test-Path $INSTALL_DIR)) {
+        New-Item -ItemType Directory -Path $INSTALL_DIR -Force | Out-Null
+    }
+
+    $destination = Join-Path $INSTALL_DIR "$BINARY_NAME.exe"
+
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $destination -UseBasicParsing
+    } catch {
+        Write-Err "Download failed. Check if a release exists for windows-$arch. Error: $_"
+    }
+
+    Write-Success "Installed $BINARY_NAME to $destination"
+
+    # Add to PATH if not already there
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($userPath -notlike "*$INSTALL_DIR*") {
+        [Environment]::SetEnvironmentVariable("Path", "$userPath;$INSTALL_DIR", "User")
+        $env:Path = "$env:Path;$INSTALL_DIR"
+        Write-Info "Added $INSTALL_DIR to your PATH."
+    }
+}
+
+# ─── Skills Prompt ──────────────────────────────────────────────────────────
+
+function Prompt-InstallSkills {
+    Write-Host ""
+    $answer = Read-Host "Would you like to install Octopus skills for Claude Code? (y/N)"
+    if ($answer -match "^[yY]") {
+        Write-Info "Installing skills..."
+        try {
+            & (Join-Path $INSTALL_DIR "$BINARY_NAME.exe") skills install --all
+        } catch {
+            Write-Warn "Could not install skills automatically. Run 'octopus skills install --all' after logging in."
+        }
+    } else {
+        Write-Info "Skipped. You can install skills later with: octopus skills install --all"
+    }
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Info "  Octopus CLI Installer"
+Write-Info "  ====================="
+Write-Host ""
+
+$arch = Get-Arch
+Write-Info "Detected platform: windows-$arch"
+
+Install-Octopus
+Prompt-InstallSkills
+
+Write-Host ""
+Write-Success "Done! Get started with:"
+Write-Success "  octopus login"
+Write-Host ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,10 +47,17 @@ get_latest_version() {
   need_cmd curl
 
   local url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-  VERSION=$(curl -fsSL "$url" | grep '"tag_name"' | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+  local response
+  response=$(curl -fsSL "$url") || error "Failed to fetch release info from GitHub. You may be rate-limited."
+
+  if command -v jq > /dev/null 2>&1; then
+    VERSION=$(echo "$response" | jq -r '.tag_name // empty')
+  else
+    VERSION=$(echo "$response" | grep '"tag_name"' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+  fi
 
   if [ -z "$VERSION" ]; then
-    error "Could not determine the latest release version."
+    error "Could not determine the latest release version. You may be rate-limited by GitHub API."
   fi
 
   info "Latest version: ${VERSION}"
@@ -75,6 +82,25 @@ download_and_install() {
   local tmpfile="${tmpdir}/${artifact}"
   curl -fsSL -o "$tmpfile" "$download_url" || error "Download failed. Check if a release exists for your platform: ${PLATFORM}-${ARCH}"
 
+  # Verify SHA256 checksum if checksums.txt is available
+  local checksums_url="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/checksums.txt"
+  local expected_sha
+  expected_sha=$(curl -fsSL "$checksums_url" 2>/dev/null | grep "${artifact}" | awk '{print $1}') || true
+  if [ -n "$expected_sha" ]; then
+    local actual_sha
+    if command -v sha256sum > /dev/null 2>&1; then
+      actual_sha=$(sha256sum "$tmpfile" | awk '{print $1}')
+    elif command -v shasum > /dev/null 2>&1; then
+      actual_sha=$(shasum -a 256 "$tmpfile" | awk '{print $1}')
+    fi
+    if [ -n "$actual_sha" ] && [ "$expected_sha" != "$actual_sha" ]; then
+      error "Checksum mismatch! Expected ${expected_sha}, got ${actual_sha}. Aborting."
+    fi
+    info "Checksum verified."
+  else
+    warn "No checksums.txt found for this release — skipping integrity check."
+  fi
+
   chmod +x "$tmpfile"
 
   # Try preferred install dir, fall back to user-local dir
@@ -86,6 +112,7 @@ download_and_install() {
     ensure_in_path "$target_dir"
   fi
 
+  INSTALLED_DIR="$target_dir"
   success "Installed ${BINARY_NAME} to ${target_dir}/${BINARY_NAME}${ext}"
 }
 
@@ -130,8 +157,7 @@ prompt_install_skills() {
   case "$answer" in
     [yY]|[yY][eE][sS])
       info "Installing skills..."
-      "${INSTALL_DIR}/${BINARY_NAME}" skills install --all 2>/dev/null \
-        || "${FALLBACK_DIR}/${BINARY_NAME}" skills install --all 2>/dev/null \
+      "${INSTALLED_DIR}/${BINARY_NAME}" skills install --all \
         || warn "Could not install skills automatically. Run 'octopus skills install --all' after logging in."
       ;;
     *)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Octopus CLI installer
+# Usage: curl -fsSL https://octopus-review.ai/install.sh | bash
+set -euo pipefail
+
+GITHUB_REPO="octopusreview/octopus-cli"
+BINARY_NAME="octopus"
+INSTALL_DIR="/usr/local/bin"
+FALLBACK_DIR="$HOME/.local/bin"
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+info()    { printf '\033[1;34m%s\033[0m\n' "$*"; }
+success() { printf '\033[1;32m%s\033[0m\n' "$*"; }
+warn()    { printf '\033[1;33m%s\033[0m\n' "$*"; }
+error()   { printf '\033[1;31merror: %s\033[0m\n' "$*" >&2; exit 1; }
+
+need_cmd() {
+  command -v "$1" > /dev/null 2>&1 || error "Required command '$1' not found. Please install it and retry."
+}
+
+# ─── Detect OS & Arch ──────────────────────────────────────────────────────
+
+detect_platform() {
+  local os arch
+
+  case "$(uname -s)" in
+    Linux*)  os="linux" ;;
+    Darwin*) os="darwin" ;;
+    MINGW*|MSYS*|CYGWIN*) os="windows" ;;
+    *) error "Unsupported operating system: $(uname -s)" ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64)  arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) error "Unsupported architecture: $(uname -m)" ;;
+  esac
+
+  PLATFORM="${os}"
+  ARCH="${arch}"
+}
+
+# ─── Fetch latest release tag from GitHub ───────────────────────────────────
+
+get_latest_version() {
+  need_cmd curl
+
+  local url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+  VERSION=$(curl -fsSL "$url" | grep '"tag_name"' | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+
+  if [ -z "$VERSION" ]; then
+    error "Could not determine the latest release version."
+  fi
+
+  info "Latest version: ${VERSION}"
+}
+
+# ─── Download & Install ────────────────────────────────────────────────────
+
+download_and_install() {
+  local ext=""
+  if [ "$PLATFORM" = "windows" ]; then
+    ext=".exe"
+  fi
+
+  local artifact="${BINARY_NAME}-${PLATFORM}-${ARCH}${ext}"
+  local download_url="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${artifact}"
+
+  info "Downloading ${artifact}..."
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  local tmpfile="${tmpdir}/${artifact}"
+  curl -fsSL -o "$tmpfile" "$download_url" || error "Download failed. Check if a release exists for your platform: ${PLATFORM}-${ARCH}"
+
+  chmod +x "$tmpfile"
+
+  # Try preferred install dir, fall back to user-local dir
+  local target_dir="$INSTALL_DIR"
+  if ! install_binary "$tmpfile" "$target_dir" 2>/dev/null; then
+    target_dir="$FALLBACK_DIR"
+    mkdir -p "$target_dir"
+    install_binary "$tmpfile" "$target_dir"
+    ensure_in_path "$target_dir"
+  fi
+
+  success "Installed ${BINARY_NAME} to ${target_dir}/${BINARY_NAME}${ext}"
+}
+
+install_binary() {
+  local src="$1" dir="$2"
+  local ext=""
+  if [ "$PLATFORM" = "windows" ]; then ext=".exe"; fi
+
+  if [ -w "$dir" ]; then
+    cp "$src" "${dir}/${BINARY_NAME}${ext}"
+  else
+    info "Writing to ${dir} requires elevated permissions..."
+    sudo cp "$src" "${dir}/${BINARY_NAME}${ext}"
+  fi
+}
+
+ensure_in_path() {
+  local dir="$1"
+  case ":$PATH:" in
+    *":${dir}:"*) ;;
+    *)
+      warn "${dir} is not in your PATH."
+      warn "Add this to your shell profile:"
+      warn "  export PATH=\"${dir}:\$PATH\""
+      ;;
+  esac
+}
+
+# ─── Skills prompt ──────────────────────────────────────────────────────────
+
+prompt_install_skills() {
+  # If running non-interactively (piped), skip prompt
+  if [ ! -t 0 ]; then
+    info ""
+    info "To install skills later, run: octopus skills install --all"
+    return
+  fi
+
+  echo ""
+  printf 'Would you like to install Octopus skills for Claude Code? (y/N) '
+  read -r answer
+  case "$answer" in
+    [yY]|[yY][eE][sS])
+      info "Installing skills..."
+      "${INSTALL_DIR}/${BINARY_NAME}" skills install --all 2>/dev/null \
+        || "${FALLBACK_DIR}/${BINARY_NAME}" skills install --all 2>/dev/null \
+        || warn "Could not install skills automatically. Run 'octopus skills install --all' after logging in."
+      ;;
+    *)
+      info "Skipped. You can install skills later with: octopus skills install --all"
+      ;;
+  esac
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  info "  Octopus CLI Installer"
+  info "  ====================="
+  echo ""
+
+  detect_platform
+  info "Detected platform: ${PLATFORM}-${ARCH}"
+
+  get_latest_version
+  download_and_install
+  prompt_install_skills
+
+  echo ""
+  success "Done! Get started with:"
+  success "  octopus login"
+  echo ""
+}
+
+main


### PR DESCRIPTION
Adds install.sh (macOS/Linux) and install.ps1 (Windows) that download
the correct binary from GitHub Releases based on OS/arch detection,
and optionally prompt to install skills for Claude Code.

Usage:
  curl -fsSL https://octopus-review.ai/install.sh | bash
  irm https://octopus-review.ai/install.ps1 | iex

https://claude.ai/code/session_01EZtW6M5F828CEPNyd4Evib