### PR TITLE
ci: add release binary builds with bun compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: bun-linux-x64
+            artifact: octopus-linux-x64
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: octopus-linux-arm64
+          - os: macos-latest
+            target: bun-darwin-x64
+            artifact: octopus-darwin-x64
+          - os: macos-latest
+            target: bun-darwin-arm64
+            artifact: octopus-darwin-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build binary
+        run: |
+          bun build ./src/index.ts \
+            --compile \
+            --target=${{ matrix.target }} \
+            --outfile=octopus
+
+      - name: Compress binary (tar.gz)
+        run: |
+          tar -czf ${{ matrix.artifact }}.tar.gz octopus
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            ${{ matrix.artifact }}.tar.gz \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,41 @@ jobs:
         run: |
           tar -czf ${{ matrix.artifact }}.tar.gz octopus
 
+      - name: Generate checksum
+        run: |
+          shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            ${{ matrix.artifact }}.tar.gz
+            ${{ matrix.artifact }}.sha256
+
+  upload:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Merge checksums
+        run: |
+          cat artifacts/*/*.sha256 | sort > checksums.txt
+
       - name: Upload to GitHub Release
-        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
-            ${{ matrix.artifact }}.tar.gz \
-            --clobber
+          for dir in artifacts/*/; do
+            for file in "$dir"*.tar.gz; do
+              [ -f "$file" ] && gh release upload "${{ github.event.release.tag_name }}" "$file" --clobber
+            done
+          done
+          gh release upload "${{ github.event.release.tag_name }}" checksums.txt --clobber


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that builds cross-platform binaries (linux-x64, linux-arm64, darwin-x64, darwin-arm64) using `bun build --compile` on every release publish
- Generates `checksums.txt` with SHA256 hashes for all binaries and uploads alongside release assets
- Includes `workflow_dispatch` trigger for manual testing

## Test plan
- [x] Tested with pre-release `v0.1.8-rc.2` — all 4 platform builds succeeded
- [x] Verified all 5 assets uploaded to release (4 tar.gz + checksums.txt)
- [x] Verified checksums.txt contains correct SHA256 hashes for each binary
- [x] Test releases cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)