### PR TITLE
fix: release workflow improvements from review feedback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,11 @@ jobs:
 
       - name: Generate checksum
         run: |
-          shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.sha256
+          if command -v sha256sum > /dev/null 2>&1; then
+            sha256sum ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.sha256
+          else
+            shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.sha256
+          fi
         shell: bash
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           - os: macos-latest
             target: bun-darwin-arm64
             artifact: octopus-darwin-arm64
+          - os: windows-latest
+            target: bun-windows-x64
+            artifact: octopus-windows-x64
 
     runs-on: ${{ matrix.os }}
 
@@ -33,10 +36,10 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.2"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build binary
         run: |
@@ -45,13 +48,27 @@ jobs:
             --target=${{ matrix.target }} \
             --outfile=octopus
 
+      - name: Verify binary exists
+        run: |
+          if [ ! -f octopus ] && [ ! -f octopus.exe ]; then
+            echo "::error::Binary was not produced by bun build --compile"
+            exit 1
+          fi
+        shell: bash
+
       - name: Compress binary (tar.gz)
         run: |
-          tar -czf ${{ matrix.artifact }}.tar.gz octopus
+          if [ -f octopus.exe ]; then
+            tar -czf ${{ matrix.artifact }}.tar.gz octopus.exe
+          else
+            tar -czf ${{ matrix.artifact }}.tar.gz octopus
+          fi
+        shell: bash
 
       - name: Generate checksum
         run: |
           shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.sha256
+        shell: bash
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Follow-up to #12, addressing review feedback from Octopus Review:

- Pin `bun-version` to `1.2` instead of `latest` for reproducible builds
- Add `--frozen-lockfile` to `bun install`
- Add Windows x64 (`bun-windows-x64`) target to the build matrix
- Add binary existence verification before the compress step
- Add `shell: bash` to cross-platform steps for Windows compatibility

## Test plan
- [ ] Verify all 5 platform builds pass (linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64)
- [ ] Verify Windows binary is correctly packaged as `.exe` inside tar.gz
- [ ] Verify checksums.txt includes Windows binary hash

🤖 Generated with [Claude Code](https://claude.com/claude-code)