### PR TITLE
feat: add agent stop command

### DIFF
--- a/src/commands/agent/index.ts
+++ b/src/commands/agent/index.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 import { watchCommand } from "./watch.js";
 import { startCommand } from "./start.js";
+import { stopCommand } from "./stop.js";
 
 export const agentCommand = new Command("agent")
   .description("Local agent for real-time codebase search")
   .addCommand(watchCommand)
-  .addCommand(startCommand);
+  .addCommand(startCommand)
+  .addCommand(stopCommand);

--- a/src/commands/agent/stop.ts
+++ b/src/commands/agent/stop.ts
@@ -15,7 +15,7 @@ export const stopCommand = new Command("stop")
     }
 
     const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
-    if (isNaN(pid)) {
+    if (isNaN(pid) || pid <= 0) {
       error("Invalid PID file. Removing it.");
       unlinkSync(pidFile);
       return;

--- a/src/commands/agent/stop.ts
+++ b/src/commands/agent/stop.ts
@@ -1,0 +1,39 @@
+import { Command } from "commander";
+import { readFileSync, unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { success, error, info } from "../../lib/output.js";
+
+const pidFile = join(homedir(), ".octopus", "agent.pid");
+
+export const stopCommand = new Command("stop")
+  .description("Stop the local agent daemon")
+  .action(() => {
+    if (!existsSync(pidFile)) {
+      info("No running agent found.");
+      return;
+    }
+
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    if (isNaN(pid)) {
+      error("Invalid PID file. Removing it.");
+      unlinkSync(pidFile);
+      return;
+    }
+
+    try {
+      process.kill(pid, "SIGTERM");
+      success(`Agent stopped (PID: ${pid}).`);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ESRCH") {
+        info("Agent process was not running.");
+      } else {
+        error(`Failed to stop agent: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
+    try {
+      unlinkSync(pidFile);
+    } catch {}
+  });


### PR DESCRIPTION
## Summary
- New `octopus agent stop` command to gracefully stop the local agent daemon
- Reads PID from `~/.octopus/agent.pid` and sends SIGTERM
- Handles missing PID file, invalid PID, and already-stopped processes

Closes #15

## Files Changed
- `src/commands/agent/stop.ts` (new)
- `src/commands/agent/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/octopusreview/octopus-cli/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
