### PR TITLE
feat: add Claude CLI answer task type for agent

### DIFF
--- a/src/commands/agent/claude-searcher.ts
+++ b/src/commands/agent/claude-searcher.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 
 const MAX_SUMMARY_SIZE = 15 * 1024; // 15KB
 
@@ -49,4 +49,62 @@ export async function claudeSearch(
     const message = err instanceof Error ? err.message : "Unknown error";
     throw new Error(`Claude CLI search failed: ${message}`);
   }
+}
+
+const MAX_ANSWER_SIZE = 100 * 1024; // 100KB
+
+interface AnswerTaskParams {
+  systemPrompt: string;
+  contextSections: string;
+  conversationHistory: { role: string; content: string }[];
+}
+
+/**
+ * Generate a full answer using Claude CLI with Qdrant context + local codebase.
+ * The prompt is piped via stdin to avoid shell argument length limits.
+ */
+export async function claudeAnswer(
+  task: { query: string; params: Record<string, unknown> },
+  repoDir: string,
+  timeoutMs = 115_000,
+): Promise<string> {
+  const { systemPrompt, contextSections, conversationHistory } = task.params as unknown as AnswerTaskParams;
+
+  const augmentedSystemPrompt = `${systemPrompt}
+
+IMPORTANT: You have access to BOTH the retrieved context sections below AND the actual local codebase in your working directory. The context sections come from an indexed knowledge base which may be stale. You are running in the actual repo directory — use your tools to read files, search code, and verify information against the real current state. If you find discrepancies between the indexed context and actual files, prefer the actual files and note the difference.`;
+
+  const historyText = conversationHistory
+    .map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.content}`)
+    .join("\n\n");
+
+  const fullPrompt = `${augmentedSystemPrompt}
+
+---
+${contextSections}
+---
+
+Conversation:
+${historyText}`;
+
+  const result = spawnSync("claude", ["-p", "--max-tokens", "4096"], {
+    input: fullPrompt,
+    cwd: repoDir,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: timeoutMs,
+  });
+
+  if (result.error) {
+    throw new Error(`Claude CLI answer failed: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.slice(0, 500) ?? "";
+    throw new Error(`Claude CLI exited with code ${result.status}: ${stderr}`);
+  }
+
+  const answer = (result.stdout ?? "").trim();
+  return answer.length > MAX_ANSWER_SIZE ? answer.slice(0, MAX_ANSWER_SIZE) : answer;
 }

--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -312,7 +312,7 @@ async function handleTask(
 
       case "answer": {
         if (claudeAvailable) {
-          resultSummary = await claudeAnswer(task, repoDir, task.timeoutMs - 5000);
+          resultSummary = await claudeAnswer(task, repoDir, Math.max(task.timeoutMs - 5000, 10_000));
         } else {
           throw new Error("Answer task requires Claude CLI");
         }

--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -10,7 +10,7 @@ import { getApiUrl, getApiToken } from "../../lib/config-store.js";
 import { success, error, warn, info } from "../../lib/output.js";
 import { loadWatchConfig, type WatchEntry } from "./watch.js";
 import { semanticSearch, grepSearch, fileReadSearch } from "./searcher.js";
-import { hasClaudeCli, claudeSearch } from "./claude-searcher.js";
+import { hasClaudeCli, claudeSearch, claudeAnswer } from "./claude-searcher.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -310,6 +310,15 @@ async function handleTask(
         break;
       }
 
+      case "answer": {
+        if (claudeAvailable) {
+          resultSummary = await claudeAnswer(task, repoDir, task.timeoutMs - 5000);
+        } else {
+          throw new Error("Answer task requires Claude CLI");
+        }
+        break;
+      }
+
       case "semantic":
       default: {
         const { summary } = await semanticSearch(task.query, repoDir);
@@ -326,6 +335,9 @@ async function handleTask(
 
     if (verbose) {
       success(`Completed task ${task.id} (${resultSummary.length} chars)`);
+      console.log(chalk.dim("─".repeat(60)));
+      console.log(resultSummary);
+      console.log(chalk.dim("─".repeat(60)));
     } else {
       console.log(
         `${chalk.green("✓")} Searched "${task.query.slice(0, 50)}${task.query.length > 50 ? "..." : ""}" in ${chalk.cyan(task.repoFullName)}`,


### PR DESCRIPTION
## Summary
- Add `claudeAnswer()` function in `claude-searcher.ts` for full answer generation using Claude CLI with Qdrant context + local codebase access
- Handle new `"answer"` task type in agent task handler
- Print task result content in verbose mode with separator lines for debugging

Closes #16

## Files Changed
- `src/commands/agent/claude-searcher.ts`
- `src/commands/agent/start.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)