### PR TITLE
refactor: detect compiled binary for agent daemon spawning

### DIFF
--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -96,16 +96,37 @@ export const startCommand = new Command("start")
 
     // Default: background mode — spawn detached child and exit
     if (!runInForeground) {
-      const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
-      if (!existsSync(binPath)) {
-        error(`Could not locate agent binary at: ${binPath}`);
-        process.exit(1);
+      // Detect if running as a compiled binary (Bun single-file executable)
+      const isCompiledBinary = !process.execPath.includes("node") && !process.execPath.includes("bun") && existsSync(process.execPath);
+
+      let execPath: string;
+      let args: string[];
+
+      if (isCompiledBinary) {
+        execPath = process.execPath;
+        args = ["agent", "start", "--foreground"];
+      } else {
+        // For npm-installed or dev usage, use process.argv[1] (the entry script)
+        // which is more reliable than computing a relative path from __dirname
+        const entryScript = process.argv[1];
+        if (!entryScript || !existsSync(entryScript)) {
+          // Fallback to __dirname-based resolution
+          const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
+          if (!existsSync(binPath)) {
+            error(`Could not locate agent binary at: ${binPath}`);
+            process.exit(1);
+          }
+          execPath = process.execPath;
+          args = [binPath, "agent", "start", "--foreground"];
+        } else {
+          execPath = process.execPath;
+          args = [entryScript, "agent", "start", "--foreground"];
+        }
       }
 
-      const args = [binPath, "agent", "start", "--foreground"];
       if (opts.withClaude) args.push("--with-claude");
 
-      const child = spawn(process.execPath, args, {
+      const child = spawn(execPath, args, {
         detached: true,
         stdio: "ignore",
       });

--- a/src/commands/agent/watch.ts
+++ b/src/commands/agent/watch.ts
@@ -153,15 +153,30 @@ export const watchCommand = new Command("watch")
       info("Starting agent...\n");
       // Detect if running as a compiled binary (Bun single-file executable)
       const isCompiledBinary = !process.execPath.includes("node") && !process.execPath.includes("bun") && existsSync(process.execPath);
-      const binPath = isCompiledBinary
-        ? process.execPath
-        : join(__dirname, "..", "..", "..", "bin", "octopus.js");
-      const args = isCompiledBinary
-        ? ["agent", "start"]
-        : [binPath, "agent", "start"];
+
+      let execPath: string;
+      let args: string[];
+
+      if (isCompiledBinary) {
+        execPath = process.execPath;
+        args = ["agent", "start"];
+      } else {
+        const entryScript = process.argv[1];
+        if (!entryScript || !existsSync(entryScript)) {
+          const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
+          if (!existsSync(binPath)) {
+            error(`Could not locate agent binary at: ${binPath}`);
+            process.exit(1);
+          }
+          execPath = process.execPath;
+          args = [binPath, "agent", "start"];
+        } else {
+          execPath = process.execPath;
+          args = [entryScript, "agent", "start"];
+        }
+      }
       if (opts.verbose) args.push("--verbose");
 
-      const execPath = isCompiledBinary ? binPath : process.execPath;
       const child = spawn(execPath, args, {
         stdio: "inherit",
       });

--- a/src/commands/agent/watch.ts
+++ b/src/commands/agent/watch.ts
@@ -151,11 +151,18 @@ export const watchCommand = new Command("watch")
 
     if (opts.start !== false) {
       info("Starting agent...\n");
-      const binPath = join(__dirname, "..", "..", "..", "bin", "octopus.js");
-      const args = [binPath, "agent", "start"];
+      // Detect if running as a compiled binary (Bun single-file executable)
+      const isCompiledBinary = !process.execPath.includes("node") && !process.execPath.includes("bun") && existsSync(process.execPath);
+      const binPath = isCompiledBinary
+        ? process.execPath
+        : join(__dirname, "..", "..", "..", "bin", "octopus.js");
+      const args = isCompiledBinary
+        ? ["agent", "start"]
+        : [binPath, "agent", "start"];
       if (opts.verbose) args.push("--verbose");
 
-      const child = spawn(process.execPath, args, {
+      const execPath = isCompiledBinary ? binPath : process.execPath;
+      const child = spawn(execPath, args, {
         stdio: "inherit",
       });
       await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- Detect compiled Bun single-file executable vs node/npm-installed environment when spawning the background agent daemon
- Use `process.argv[1]` for npm/dev installations instead of fragile `__dirname` relative paths
- Apply same fix to both `start.ts` (background spawn) and `watch.ts` (agent start)

Closes #17

## Files Changed
- `src/commands/agent/start.ts`
- `src/commands/agent/watch.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)