### PR TITLE
fix: agent search improvements and error logging

### DIFF
--- a/src/commands/agent/searcher.ts
+++ b/src/commands/agent/searcher.ts
@@ -63,7 +63,7 @@ function extractKeywords(query: string): string[] {
  */
 function ripgrep(pattern: string, dir: string, maxResults = 20): SearchResult[] {
   try {
-    const rgCmd = `rg --no-heading --line-number --max-count 5 --max-columns 200 --type-add 'code:*.{ts,tsx,js,jsx,py,go,rs,java,rb,php,c,cpp,h,cs,swift,kt,scala,vue,svelte}' --type code --glob '!node_modules' --glob '!dist' --glob '!.git' --glob '!*.lock' --glob '!*.min.*' -- ${JSON.stringify(pattern)} ${JSON.stringify(dir)}`;
+    const rgCmd = `rg --no-heading --line-number --max-count 5 --max-columns 200 --type-add 'searchable:*.{ts,tsx,js,jsx,py,go,rs,java,rb,php,c,cpp,h,cs,swift,kt,scala,vue,svelte,md,json,yaml,yml,toml,xml,html,css,scss,txt}' --type searchable --glob '!node_modules' --glob '!dist' --glob '!.git' --glob '!*.lock' --glob '!*.min.*' -- ${JSON.stringify(pattern)} ${JSON.stringify(dir)}`;
     const output = execSync(rgCmd, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -94,11 +94,13 @@ function ripgrep(pattern: string, dir: string, maxResults = 20): SearchResult[] 
   }
 }
 
-const CODE_EXTENSIONS = new Set([
+const SEARCHABLE_EXTENSIONS = new Set([
   ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
   ".py", ".go", ".rs", ".java", ".rb", ".php",
   ".c", ".cpp", ".h", ".cs", ".swift", ".kt",
   ".scala", ".vue", ".svelte",
+  ".md", ".json", ".yaml", ".yml", ".toml",
+  ".xml", ".html", ".css", ".scss", ".txt",
 ]);
 
 const SKIP_DIRS = new Set([
@@ -138,7 +140,7 @@ function nodeSearch(pattern: string, dir: string, maxResults = 20): SearchResult
 
       if (stat.isDirectory()) {
         walk(fullPath);
-      } else if (stat.isFile() && CODE_EXTENSIONS.has(extname(entry))) {
+      } else if (stat.isFile() && SEARCHABLE_EXTENSIONS.has(extname(entry))) {
         // Skip large files (>200KB)
         if (stat.size > 200_000) continue;
 

--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -82,10 +82,10 @@ function resolveWatchedRepos(): Map<string, string> {
 
 export const startCommand = new Command("start")
   .description("Start the local agent daemon")
-  .option("--with-claude", "Enable Claude CLI for deep semantic search")
+  .option("--no-claude", "Disable Claude CLI (use ripgrep only)")
   .option("--verbose", "Run in foreground with detailed logs")
   .option("--foreground", "Run in foreground (without verbose logs)")
-  .action(async (opts: { withClaude?: boolean; verbose?: boolean; foreground?: boolean }) => {
+  .action(async (opts: { claude?: boolean; verbose?: boolean; foreground?: boolean }) => {
     const token = getApiToken();
     if (!token) {
       error("Not logged in. Run 'octopus login' first.");
@@ -103,7 +103,7 @@ export const startCommand = new Command("start")
       }
 
       const args = [binPath, "agent", "start", "--foreground"];
-      if (opts.withClaude) args.push("--with-claude");
+      if (opts.claude === false) args.push("--no-claude");
 
       const child = spawn(process.execPath, args, {
         detached: true,
@@ -141,9 +141,9 @@ export const startCommand = new Command("start")
       console.log(`  ${chalk.cyan(name)} → ${path}`);
     }
 
-    // Check Claude CLI availability
-    const claudeAvailable = opts.withClaude ? hasClaudeCli() : false;
-    if (opts.withClaude && !claudeAvailable) {
+    // Check Claude CLI availability (enabled by default, disable with --no-claude)
+    const claudeAvailable = opts.claude !== false ? hasClaudeCli() : false;
+    if (opts.claude !== false && !claudeAvailable) {
       warn("Claude CLI not found. Falling back to ripgrep mode.");
     }
 
@@ -193,9 +193,10 @@ export const startCommand = new Command("start")
         if (verbose) {
           info(`Heartbeat sent (${freshNames.length} repos)`);
         }
-      } catch (err) {
+      } catch (err: unknown) {
         if (verbose) {
-          warn(`Heartbeat failed: ${err instanceof Error ? err.message : err}`);
+          const e = err as { status?: number; url?: string; message?: string };
+          warn(`Heartbeat failed: ${e.message}${e.status ? ` [${e.status}]` : ""}${e.url ? ` → ${e.url}` : ""}`);
         }
       }
     }, 30_000);
@@ -212,9 +213,10 @@ export const startCommand = new Command("start")
         for (const task of res.tasks) {
           handleTask(task, repoMap, agentId, claudeAvailable, verbose);
         }
-      } catch (err) {
+      } catch (err: unknown) {
         if (verbose) {
-          warn(`Poll failed: ${err instanceof Error ? err.message : err}`);
+          const e = err as { status?: number; url?: string; message?: string };
+          warn(`Poll failed: ${e.message}${e.status ? ` [${e.status}]` : ""}${e.url ? ` → ${e.url}` : ""}`);
         }
       }
     }, 2_000);

--- a/src/commands/agent/start.ts
+++ b/src/commands/agent/start.ts
@@ -83,9 +83,14 @@ function resolveWatchedRepos(): Map<string, string> {
 export const startCommand = new Command("start")
   .description("Start the local agent daemon")
   .option("--no-claude", "Disable Claude CLI (use ripgrep only)")
+  .option("--with-claude", "[deprecated] Claude is now enabled by default. Use --no-claude to disable it.")
   .option("--verbose", "Run in foreground with detailed logs")
   .option("--foreground", "Run in foreground (without verbose logs)")
-  .action(async (opts: { claude?: boolean; verbose?: boolean; foreground?: boolean }) => {
+  .action(async (opts: { claude?: boolean; withClaude?: boolean; verbose?: boolean; foreground?: boolean }) => {
+    if (opts.withClaude) {
+      warn("--with-claude is deprecated and has no effect. Claude is now enabled by default. Use --no-claude to disable it.");
+    }
+
     const token = getApiToken();
     if (!token) {
       error("Not logged in. Run 'octopus login' first.");


### PR DESCRIPTION
## Summary
- Expand searchable file extensions to include .md, .json, .yaml, .yml, .toml, .xml, .html, .css, .scss, .txt
- Change `--with-claude` to `--no-claude` (Claude CLI enabled by default now)
- Improve error logging in heartbeat/poll with status code and URL context

Closes #18

## Files Changed
- `src/commands/agent/searcher.ts`
- `src/commands/agent/start.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)