### PR TITLE
feat: add setup-token command for CI/CD-friendly token retrieval

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,124 +1,8 @@
 import { Command } from "commander";
-import { createInterface } from "node:readline/promises";
-import { stdin, stdout } from "node:process";
-import { exec } from "node:child_process";
 import { setProfile, getApiUrl } from "../lib/config-store.js";
 import { success, error, info } from "../lib/output.js";
 import { withSpinner } from "../lib/spinner.js";
-import chalk from "chalk";
-
-const MAX_POLL_ATTEMPTS = 200;
-const POLL_INTERVAL_MS = 2000;
-
-function openBrowser(url: string): void {
-  try {
-    new URL(url);
-  } catch {
-    throw new Error("Invalid authorization URL");
-  }
-
-  if (process.platform === "win32") {
-    exec(`start "" "${url}"`);
-  } else {
-    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
-    exec(`${cmd} "${url}"`);
-  }
-}
-
-async function deviceFlow(apiUrl: string, profile: string): Promise<void> {
-  // Step 1: Request a device code
-  const deviceRes = await fetch(`${apiUrl}/api/cli/auth/device`, {
-    method: "POST",
-  });
-
-  if (!deviceRes.ok) {
-    if (deviceRes.status === 404) {
-      throw new Error("Device authorization endpoint not found. Is the server up to date?");
-    }
-    if (deviceRes.status === 429) {
-      throw new Error("Too many login attempts. Please wait a minute and try again.");
-    }
-    throw new Error(`Failed to initiate login (HTTP ${deviceRes.status}). Is the server running?`);
-  }
-
-  const deviceData = (await deviceRes.json()) as Record<string, unknown>;
-  const deviceCode = deviceData.deviceCode;
-  const expiresAt = deviceData.expiresAt;
-  if (typeof deviceCode !== "string" || typeof expiresAt !== "string") {
-    throw new Error("Invalid response from device authorization endpoint");
-  }
-
-  // Step 2: Open browser
-  const authorizeUrl = `${apiUrl}/cli/authorize?code=${deviceCode}`;
-
-  info("");
-  info("Opening browser to authorize...");
-  info(chalk.dim(authorizeUrl));
-  info("");
-
-  openBrowser(authorizeUrl);
-
-  info("Waiting for authorization (press Ctrl+C to cancel)...");
-
-  // Step 3: Poll for token
-  const expiry = new Date(expiresAt).getTime();
-  let attempts = 0;
-
-  while (attempts < MAX_POLL_ATTEMPTS) {
-    if (Date.now() > expiry) {
-      throw new Error("Authorization timed out. Please try again.");
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    attempts++;
-
-    let pollRes: Response;
-    try {
-      pollRes = await fetch(
-        `${apiUrl}/api/cli/auth/poll?device_code=${deviceCode}`,
-      );
-    } catch (networkError) {
-      if (attempts > 5) {
-        throw new Error(`Network error during authorization: ${networkError instanceof Error ? networkError.message : String(networkError)}`);
-      }
-      continue;
-    }
-
-    if (pollRes.status === 410) {
-      throw new Error("Authorization expired. Please try again.");
-    }
-
-    if (!pollRes.ok && pollRes.status !== 200) {
-      continue;
-    }
-
-    const data = (await pollRes.json()) as {
-      status: string;
-      token?: string;
-      organization?: { id: string; slug: string; name: string };
-      user?: { name: string; email: string };
-    };
-
-    if (data.status === "approved" && data.token && data.organization) {
-      setProfile(profile, {
-        apiUrl,
-        token: data.token,
-        orgSlug: data.organization.slug,
-        orgId: data.organization.id,
-      });
-
-      const userName = data.user?.name || "Unknown User";
-      const userEmail = data.user?.email ? ` (${data.user.email})` : "";
-      info("");
-      success(
-        `Logged in as ${userName}${userEmail} — org: ${data.organization.name}`,
-      );
-      return;
-    }
-  }
-
-  throw new Error("Authorization timed out after too many attempts.");
-}
+import { runDeviceFlow } from "../lib/device-flow.js";
 
 async function tokenFlow(
   token: string,
@@ -169,15 +53,26 @@ export const loginCommand = new Command("login")
 
     try {
       if (opts.token) {
-        // Direct token flow
         if (!opts.token.startsWith("oct_")) {
           error("Invalid token format. Token must start with 'oct_'.");
           process.exit(1);
         }
         await tokenFlow(opts.token, apiUrl, opts.profile);
       } else {
-        // Device authorization flow (browser-based)
-        await deviceFlow(apiUrl, opts.profile);
+        const result = await runDeviceFlow(apiUrl);
+
+        setProfile(opts.profile, {
+          apiUrl,
+          token: result.token,
+          orgSlug: result.organization.slug,
+          orgId: result.organization.id,
+        });
+
+        const userEmail = result.user.email ? ` (${result.user.email})` : "";
+        info("");
+        success(
+          `Logged in as ${result.user.name}${userEmail} — org: ${result.organization.name}`,
+        );
       }
     } catch (err) {
       error(err instanceof Error ? err.message : "Login failed");

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import chalk from "chalk";
 import { setProfile, getApiUrl } from "../lib/config-store.js";
 import { success, error, info } from "../lib/output.js";
 import { withSpinner } from "../lib/spinner.js";
@@ -59,7 +60,9 @@ export const loginCommand = new Command("login")
         }
         await tokenFlow(opts.token, apiUrl, opts.profile);
       } else {
-        const result = await runDeviceFlow(apiUrl);
+        const result = await runDeviceFlow(apiUrl, {
+          onAuthorizeUrl: (url) => info(chalk.dim(url)),
+        });
 
         setProfile(opts.profile, {
           apiUrl,

--- a/src/commands/setup-token.ts
+++ b/src/commands/setup-token.ts
@@ -1,0 +1,46 @@
+import { Command } from "commander";
+import { getApiUrl, setProfile } from "../lib/config-store.js";
+import { error } from "../lib/output.js";
+import { runDeviceFlow } from "../lib/device-flow.js";
+
+export const setupTokenCommand = new Command("setup-token")
+  .description(
+    "Authenticate via browser and print the API token to stdout (for CI/CD setup)",
+  )
+  .option("--api-url <url>", "API base URL")
+  .option("--no-open", "Don't open the browser automatically")
+  .option("--save", "Also save the token to a local profile")
+  .option("--profile <name>", "Profile name to save to (with --save)", "default")
+  .action(async (opts) => {
+    const apiUrl = opts.apiUrl ?? getApiUrl();
+
+    try {
+      const noOpen = opts.open === false;
+
+      const result = await runDeviceFlow(apiUrl, {
+        quiet: true,
+        noOpen,
+        onAuthorizeUrl: (url) => {
+          process.stderr.write(
+            noOpen
+              ? `Open this URL in your browser to authorize:\n${url}\n`
+              : `Opening browser to authorize: ${url}\n`,
+          );
+        },
+      });
+
+      if (opts.save) {
+        setProfile(opts.profile, {
+          apiUrl,
+          token: result.token,
+          orgSlug: result.organization.slug,
+          orgId: result.organization.id,
+        });
+      }
+
+      process.stdout.write(result.token + "\n");
+    } catch (err) {
+      error(err instanceof Error ? err.message : "Failed to obtain token");
+      process.exit(1);
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
+import { setupTokenCommand } from "./commands/setup-token.js";
 import { whoamiCommand } from "./commands/whoami.js";
 import { configCommand } from "./commands/config.js";
 import { usageCommand } from "./commands/usage.js";
@@ -33,6 +34,7 @@ program
 
 program.addCommand(loginCommand);
 program.addCommand(logoutCommand);
+program.addCommand(setupTokenCommand);
 program.addCommand(whoamiCommand);
 program.addCommand(configCommand);
 program.addCommand(usageCommand);

--- a/src/lib/device-flow.ts
+++ b/src/lib/device-flow.ts
@@ -1,0 +1,134 @@
+import { exec } from "node:child_process";
+import chalk from "chalk";
+import { info } from "./output.js";
+
+const MAX_POLL_ATTEMPTS = 200;
+const POLL_INTERVAL_MS = 2000;
+
+export interface DeviceFlowResult {
+  token: string;
+  organization: { id: string; slug: string; name: string };
+  user: { name: string; email: string };
+}
+
+export interface DeviceFlowOptions {
+  /** Suppress all stdout output (for raw / scripting use). */
+  quiet?: boolean;
+  /** Skip opening the browser automatically. */
+  noOpen?: boolean;
+  /** Called with the authorization URL once obtained (e.g. to print to stderr). */
+  onAuthorizeUrl?: (url: string) => void;
+}
+
+function openBrowser(url: string): void {
+  try {
+    new URL(url);
+  } catch {
+    throw new Error("Invalid authorization URL");
+  }
+
+  if (process.platform === "win32") {
+    exec(`start "" "${url}"`);
+  } else {
+    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+    exec(`${cmd} "${url}"`);
+  }
+}
+
+export async function runDeviceFlow(
+  apiUrl: string,
+  options: DeviceFlowOptions = {},
+): Promise<DeviceFlowResult> {
+  const { quiet = false, noOpen = false, onAuthorizeUrl } = options;
+  const log = quiet ? () => {} : info;
+
+  const deviceRes = await fetch(`${apiUrl}/api/cli/auth/device`, {
+    method: "POST",
+  });
+
+  if (!deviceRes.ok) {
+    if (deviceRes.status === 404) {
+      throw new Error("Device authorization endpoint not found. Is the server up to date?");
+    }
+    if (deviceRes.status === 429) {
+      throw new Error("Too many login attempts. Please wait a minute and try again.");
+    }
+    throw new Error(`Failed to initiate login (HTTP ${deviceRes.status}). Is the server running?`);
+  }
+
+  const deviceData = (await deviceRes.json()) as Record<string, unknown>;
+  const deviceCode = deviceData.deviceCode;
+  const expiresAt = deviceData.expiresAt;
+  if (typeof deviceCode !== "string" || typeof expiresAt !== "string") {
+    throw new Error("Invalid response from device authorization endpoint");
+  }
+
+  const authorizeUrl = `${apiUrl}/cli/authorize?code=${deviceCode}`;
+
+  onAuthorizeUrl?.(authorizeUrl);
+
+  log("");
+  log(noOpen ? "Open the following URL in your browser to authorize:" : "Opening browser to authorize...");
+  log(chalk.dim(authorizeUrl));
+  log("");
+
+  if (!noOpen) {
+    openBrowser(authorizeUrl);
+  }
+
+  log("Waiting for authorization (press Ctrl+C to cancel)...");
+
+  const expiry = new Date(expiresAt).getTime();
+  let attempts = 0;
+
+  while (attempts < MAX_POLL_ATTEMPTS) {
+    if (Date.now() > expiry) {
+      throw new Error("Authorization timed out. Please try again.");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    attempts++;
+
+    let pollRes: Response;
+    try {
+      pollRes = await fetch(
+        `${apiUrl}/api/cli/auth/poll?device_code=${deviceCode}`,
+      );
+    } catch (networkError) {
+      if (attempts > 5) {
+        throw new Error(
+          `Network error during authorization: ${networkError instanceof Error ? networkError.message : String(networkError)}`,
+        );
+      }
+      continue;
+    }
+
+    if (pollRes.status === 410) {
+      throw new Error("Authorization expired. Please try again.");
+    }
+
+    if (!pollRes.ok && pollRes.status !== 200) {
+      continue;
+    }
+
+    const data = (await pollRes.json()) as {
+      status: string;
+      token?: string;
+      organization?: { id: string; slug: string; name: string };
+      user?: { name: string; email: string };
+    };
+
+    if (data.status === "approved" && data.token && data.organization) {
+      return {
+        token: data.token,
+        organization: data.organization,
+        user: {
+          name: data.user?.name ?? "Unknown User",
+          email: data.user?.email ?? "",
+        },
+      };
+    }
+  }
+
+  throw new Error("Authorization timed out after too many attempts.");
+}

--- a/src/lib/device-flow.ts
+++ b/src/lib/device-flow.ts
@@ -1,5 +1,4 @@
 import { exec } from "node:child_process";
-import chalk from "chalk";
 import { info } from "./output.js";
 
 const MAX_POLL_ATTEMPTS = 200;
@@ -65,11 +64,13 @@ export async function runDeviceFlow(
 
   const authorizeUrl = `${apiUrl}/cli/authorize?code=${deviceCode}`;
 
+  // The URL is intentionally only emitted through onAuthorizeUrl so callers
+  // control its destination (stdout / stderr / silent). Never write it via
+  // log() — that would pollute stdout for stream-capturing callers.
   onAuthorizeUrl?.(authorizeUrl);
 
   log("");
-  log(noOpen ? "Open the following URL in your browser to authorize:" : "Opening browser to authorize...");
-  log(chalk.dim(authorizeUrl));
+  log(noOpen ? "Open the URL above in your browser to authorize." : "Opening browser to authorize...");
   log("");
 
   if (!noOpen) {


### PR DESCRIPTION
## Summary
- New `octopus setup-token` command: runs the existing browser device flow but prints the API token to stdout (progress on stderr) so it can be captured with `export OCTOPUS_TOKEN=\$(octopus setup-token)` or redirected to a file.
- Extracted the browser device-flow logic out of `login.ts` into `lib/device-flow.ts` so both commands share one implementation.
- `--save` flag persists the token to a local profile (off by default — keeps it ephemeral for CI use).
- `--no-open` for headless boxes; the URL is written to stderr so the user can open it elsewhere.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` passes
- [x] Smoke-tested locally: `octopus setup-token > /tmp/t.txt` opened the browser, polled, wrote a 36-char `oct_...` token to the file, no profile was modified
- [ ] Verify `octopus login` (existing command) still works via the refactored device-flow lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)