### PR TITLE
feat: parse GitLab MR URLs & self-hosted SSH remotes, provider-aware wording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octp/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "CLI tool for Octopus — AI-powered PR review and codebase intelligence",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/pr/review.ts
+++ b/src/commands/pr/review.ts
@@ -8,6 +8,8 @@ import { createSpinner } from "../../lib/spinner.js";
  * Parse PR identifier — supports:
  * - PR number: 123
  * - GitHub URL: https://github.com/owner/repo/pull/123
+ * - Bitbucket URL: https://bitbucket.org/owner/repo/pull-requests/123
+ * - GitLab MR URL: https://gitlab.example.com/group/subgroup/repo/-/merge_requests/123
  */
 function parsePrArg(arg: string): { prNumber: number; repoFullName?: string } {
   // Try as a number
@@ -28,7 +30,36 @@ function parsePrArg(arg: string): { prNumber: number; repoFullName?: string } {
     return { prNumber: parseInt(bbMatch[2], 10), repoFullName: bbMatch[1] };
   }
 
+  // Try as a GitLab MR URL (self-hosted, custom host/port, nested subgroups).
+  // GitLab separates the project path from the resource with "/-/".
+  const glMatch = arg.match(/\/\/[^/]+\/(.+?)\/-\/merge_requests\/(\d+)/);
+  if (glMatch) {
+    return { prNumber: parseInt(glMatch[2], 10), repoFullName: glMatch[1] };
+  }
+
   throw new Error(`Invalid PR identifier: "${arg}". Use a PR number or URL.`);
+}
+
+/**
+ * Provider-specific terminology. GitLab calls them "Merge Requests" (MR),
+ * everyone else "Pull Requests" (PR). Used for user-facing output, including
+ * remapping the backend's generic "pull request" wording.
+ */
+function prTerms(provider: string): { full: string; short: string } {
+  return provider.toLowerCase() === "gitlab"
+    ? { full: "merge request", short: "MR" }
+    : { full: "pull request", short: "PR" };
+}
+
+function localizeMessage(message: string, provider: string): string {
+  if (provider.toLowerCase() !== "gitlab") return message;
+  // Preserve the casing of the matched "P" → "M" so "Pull request" → "Merge request".
+  return message
+    .replace(/pull(\s)request/gi, (_m, sp, offset, str) =>
+      (str[offset] === "P" ? "Merge" : "merge") + sp + "request",
+    )
+    .replace(/\bPRs\b/g, "MRs")
+    .replace(/\bPR\b/g, "MR");
 }
 
 export async function reviewAction(prArg: string | undefined, opts: { pr?: string }) {
@@ -37,18 +68,23 @@ export async function reviewAction(prArg: string | undefined, opts: { pr?: strin
     error("Missing PR identifier. Usage: octopus review <pr> or octopus review --pr <pr>");
     process.exit(1);
   }
+  const spinner = createSpinner("Resolving pull request...").start();
+  let provider = "";
   try {
-    const spinner = createSpinner("Resolving pull request...").start();
     const { prNumber, repoFullName } = parsePrArg(resolved);
 
     const repo = await resolveRepo(repoFullName);
-    spinner.text = `Starting review for ${repo.fullName} PR #${prNumber}...`;
+    provider = repo.provider;
+    const terms = prTerms(provider);
+    spinner.text = `Resolving ${terms.full}...`;
 
     await apiPost(`/api/cli/repos/${repo.id}/review`, { prNumber });
-    spinner.succeed(`Review triggered for ${repo.fullName} PR #${prNumber}`);
-    info("The review will be posted as a comment on the PR when complete.");
+    spinner.succeed(`Review triggered for ${repo.fullName} ${terms.short} #${prNumber}`);
+    info(`The review will be posted as a comment on the ${terms.full} when complete.`);
   } catch (err: unknown) {
-    error(err instanceof Error ? err.message : "Failed to trigger review");
+    spinner.stop();
+    const message = err instanceof Error ? err.message : "Failed to trigger review";
+    error(localizeMessage(message, provider));
     process.exit(1);
   }
 }

--- a/src/commands/pr/review.ts
+++ b/src/commands/pr/review.ts
@@ -32,7 +32,8 @@ function parsePrArg(arg: string): { prNumber: number; repoFullName?: string } {
 
   // Try as a GitLab MR URL (self-hosted, custom host/port, nested subgroups).
   // GitLab separates the project path from the resource with "/-/".
-  const glMatch = arg.match(/\/\/[^/]+\/(.+?)\/-\/merge_requests\/(\d+)/);
+  // Anchor to http(s) so only real web URLs match, not arbitrary strings/schemes.
+  const glMatch = arg.match(/https?:\/\/[^/]+\/(.+?)\/-\/merge_requests\/(\d+)/);
   if (glMatch) {
     return { prNumber: parseInt(glMatch[2], 10), repoFullName: glMatch[1] };
   }
@@ -55,8 +56,8 @@ function localizeMessage(message: string, provider: string): string {
   if (provider.toLowerCase() !== "gitlab") return message;
   // Preserve the casing of the matched "P" → "M" so "Pull request" → "Merge request".
   return message
-    .replace(/pull(\s)request/gi, (_m, sp, offset, str) =>
-      (str[offset] === "P" ? "Merge" : "merge") + sp + "request",
+    .replace(/pull(\s)request/gi, (_m, sp) =>
+      (_m[0] === "P" ? "Merge" : "merge") + sp + "request",
     )
     .replace(/\bPRs\b/g, "MRs")
     .replace(/\bPR\b/g, "MR");

--- a/src/lib/repo-resolver.ts
+++ b/src/lib/repo-resolver.ts
@@ -15,15 +15,15 @@ import type { ApiRepo } from "../types.js";
 function parseGitRemote(url: string): string | null {
   // SSH URL form: ssh://git@host[:port]/owner/repo.git
   const sshUrlMatch = url.match(/^ssh:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/);
-  if (sshUrlMatch) return sshUrlMatch[1];
+  if (sshUrlMatch && sshUrlMatch[1].length > 0) return sshUrlMatch[1];
 
   // SSH scp-like form: git@github.com:owner/repo.git
   const sshMatch = url.match(/git@[^:]+:(.+?)(?:\.git)?\/?$/);
-  if (sshMatch) return sshMatch[1];
+  if (sshMatch && sshMatch[1].length > 0) return sshMatch[1];
 
   // HTTPS form (optional port): https://github.com[:port]/owner/repo.git
   const httpsMatch = url.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/);
-  if (httpsMatch) return httpsMatch[1];
+  if (httpsMatch && httpsMatch[1].length > 0) return httpsMatch[1];
 
   return null;
 }

--- a/src/lib/repo-resolver.ts
+++ b/src/lib/repo-resolver.ts
@@ -4,18 +4,25 @@ import type { ApiRepo } from "../types.js";
 
 /**
  * Extract repo full name from git remote URL.
- * Supports both SSH and HTTPS formats:
+ * Supports SSH (scp-like and URL form) and HTTPS formats, including
+ * custom ports (self-hosted GitLab) and nested subgroup paths:
  * - git@github.com:owner/repo.git
  * - https://github.com/owner/repo.git
  * - git@bitbucket.org:owner/repo.git
+ * - ssh://git@gitlab.example.com:2222/group/subgroup/repo.git
+ * - https://gitlab.example.com:8443/group/subgroup/repo.git
  */
 function parseGitRemote(url: string): string | null {
-  // SSH format: git@github.com:owner/repo.git
-  const sshMatch = url.match(/git@[^:]+:([^/]+\/[^/]+?)(?:\.git)?$/);
+  // SSH URL form: ssh://git@host[:port]/owner/repo.git
+  const sshUrlMatch = url.match(/^ssh:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/);
+  if (sshUrlMatch) return sshUrlMatch[1];
+
+  // SSH scp-like form: git@github.com:owner/repo.git
+  const sshMatch = url.match(/git@[^:]+:(.+?)(?:\.git)?\/?$/);
   if (sshMatch) return sshMatch[1];
 
-  // HTTPS format: https://github.com/owner/repo.git
-  const httpsMatch = url.match(/https?:\/\/[^/]+\/([^/]+\/[^/]+?)(?:\.git)?$/);
+  // HTTPS form (optional port): https://github.com[:port]/owner/repo.git
+  const httpsMatch = url.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/);
   if (httpsMatch) return httpsMatch[1];
 
   return null;


### PR DESCRIPTION
## Summary
Fixes repo resolution and PR-identifier parsing for self-hosted GitLab, plus provider-aware "Merge Request" wording.

### `repo-resolver.ts` (closes #28)
- Handle `ssh://git@host[:port]/owner/repo.git` URL-form remotes (self-hosted GitLab with custom SSH port)
- Support nested subgroup paths (`group/subgroup/repo`)
- Add port support to HTTPS remotes (`https://host:8443/...`)

### `pr review`
- Parse GitLab `/-/merge_requests/N` URLs to extract repo + MR number (previously only GitHub `/pull/` and Bitbucket were supported — this was the `Invalid PR identifier` error)
- Provider-aware terminology: GitLab shows **Merge Request / MR**, others **Pull Request / PR**, including remapping backend error messages with casing preserved

### Misc
- Bump version to 0.1.15

## Testing
- `npm run build` (tsc) clean
- Verified all remote/URL forms parse correctly
- End-to-end smoke test against production: `octopus pr review <gitlab-mr-url>` → review triggered, MR fetched on-demand and review comment posted

> Backend on-demand MR/PR fetch (so unsynced MRs can be reviewed) shipped separately in octopusreview/octopus#399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)