### PR TITLE
feat: add update command to self-update CLI from npm

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,91 @@
+import { Command } from "commander";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { success, error, info, warn } from "../lib/output.js";
+import { withSpinner } from "../lib/spinner.js";
+
+const PKG_NAME = "@octp/cli";
+const REGISTRY_URL = `https://registry.npmjs.org/${PKG_NAME}/latest`;
+
+function getCurrentVersion(): string {
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, "..", "..", "package.json"), "utf-8"),
+    );
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Returns 1 if a > b, -1 if a < b, 0 if equal. */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) > (pb[i] ?? 0)) return 1;
+    if ((pa[i] ?? 0) < (pb[i] ?? 0)) return -1;
+  }
+  return 0;
+}
+
+async function fetchLatestVersion(): Promise<string> {
+  const res = await fetch(REGISTRY_URL);
+  if (!res.ok) {
+    throw new Error(`npm registry returned ${res.status}`);
+  }
+  const data = (await res.json()) as { version?: string };
+  if (!data.version) {
+    throw new Error("Could not read latest version from npm registry");
+  }
+  return data.version;
+}
+
+export const updateCommand = new Command("update")
+  .description("Update Octopus CLI to the latest version from npm")
+  .option("--check", "Only check for updates without installing")
+  .action(async (opts) => {
+    const current = getCurrentVersion();
+
+    let latest: string;
+    try {
+      latest = await withSpinner("Checking npm for the latest version", () =>
+        fetchLatestVersion(),
+      );
+    } catch (err) {
+      error(`Update check failed: ${(err as Error).message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    info(`Current version: ${current}`);
+    info(`Latest version:  ${latest}`);
+
+    if (compareSemver(latest, current) <= 0) {
+      success("You're already on the latest version.");
+      return;
+    }
+
+    if (opts.check) {
+      warn(
+        `A new version is available (${latest}). Run \`octopus update\` to install it.`,
+      );
+      return;
+    }
+
+    try {
+      await withSpinner(`Installing ${PKG_NAME}@${latest}`, async () => {
+        execSync(`npm install -g ${PKG_NAME}@latest`, { stdio: "ignore" });
+      });
+    } catch (err) {
+      error(`Update failed: ${(err as Error).message}`);
+      info(`Try running manually: npm install -g ${PKG_NAME}@latest`);
+      process.exitCode = 1;
+      return;
+    }
+
+    success(`Updated to ${latest}.`);
+  });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,23 +1,37 @@
 import { Command } from "commander";
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 import { success, error, info, warn } from "../lib/output.js";
 import { withSpinner } from "../lib/spinner.js";
+import { getVersion } from "../lib/version.js";
 
 const PKG_NAME = "@octp/cli";
 const REGISTRY_URL = `https://registry.npmjs.org/${PKG_NAME}/latest`;
 
-function getCurrentVersion(): string {
-  try {
-    const __dirname = dirname(fileURLToPath(import.meta.url));
-    const pkg = JSON.parse(
-      readFileSync(join(__dirname, "..", "..", "package.json"), "utf-8"),
-    );
-    return pkg.version ?? "0.0.0";
-  } catch {
-    return "0.0.0";
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+/**
+ * Best-effort detection of the package manager the CLI was installed with,
+ * inferred from this module's install path. Falls back to npm.
+ */
+function detectPackageManager(): PackageManager {
+  const path = fileURLToPath(import.meta.url).toLowerCase();
+  if (path.includes("pnpm")) return "pnpm";
+  if (path.includes("yarn")) return "yarn";
+  if (path.includes("bun")) return "bun";
+  return "npm";
+}
+
+function globalInstallCommand(pm: PackageManager, spec: string): string {
+  switch (pm) {
+    case "pnpm":
+      return `pnpm add -g ${spec}`;
+    case "yarn":
+      return `yarn global add ${spec}`;
+    case "bun":
+      return `bun add -g ${spec}`;
+    default:
+      return `npm install -g ${spec}`;
   }
 }
 
@@ -47,8 +61,8 @@ async function fetchLatestVersion(): Promise<string> {
 export const updateCommand = new Command("update")
   .description("Update Octopus CLI to the latest version from npm")
   .option("--check", "Only check for updates without installing")
-  .action(async (opts) => {
-    const current = getCurrentVersion();
+  .action(async (opts: { check?: boolean }): Promise<void> => {
+    const current = getVersion();
 
     let latest: string;
     try {
@@ -69,20 +83,21 @@ export const updateCommand = new Command("update")
       return;
     }
 
+    const spec = `${PKG_NAME}@latest`;
+    const installCmd = globalInstallCommand(detectPackageManager(), spec);
+
     if (opts.check) {
-      warn(
-        `A new version is available (${latest}). Run \`octopus update\` to install it.`,
-      );
+      warn(`A new version is available (${latest}). Run \`octopus update\` to install it.`);
       return;
     }
 
     try {
       await withSpinner(`Installing ${PKG_NAME}@${latest}`, async () => {
-        execSync(`npm install -g ${PKG_NAME}@latest`, { stdio: "ignore" });
+        execSync(installCmd, { stdio: "ignore" });
       });
     } catch (err) {
       error(`Update failed: ${(err as Error).message}`);
-      info(`Try running manually: npm install -g ${PKG_NAME}@latest`);
+      info(`Try running manually: ${installCmd}`);
       process.exitCode = 1;
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Command } from "commander";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { getVersion } from "./lib/version.js";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
 import { setupTokenCommand } from "./commands/setup-token.js";
@@ -17,14 +15,7 @@ import { skillsCommand, checkSkillUpdates } from "./commands/skills.js";
 import { agentCommand } from "./commands/agent/index.js";
 import { updateCommand } from "./commands/update.js";
 
-let version = "0.0.0";
-try {
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
-  version = pkg.version ?? version;
-} catch {
-  // fall back to placeholder; CLI remains functional
-}
+const version = getVersion();
 
 const program = new Command();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { knowledgeCommand } from "./commands/knowledge/index.js";
 import { analyzeDepsCommand } from "./commands/analyze-deps.js";
 import { skillsCommand, checkSkillUpdates } from "./commands/skills.js";
 import { agentCommand } from "./commands/agent/index.js";
+import { updateCommand } from "./commands/update.js";
 
 let version = "0.0.0";
 try {
@@ -44,6 +45,7 @@ program.addCommand(knowledgeCommand);
 program.addCommand(analyzeDepsCommand);
 program.addCommand(skillsCommand);
 program.addCommand(agentCommand);
+program.addCommand(updateCommand);
 
 // Top-level alias: `octopus review` → `octopus pr review`
 program

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * Reads the CLI version from the package.json shipped with the install.
+ * Single source of truth — used by both the program version flag and the
+ * `update` command so the path resolution can never diverge.
+ */
+export function getVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "..", "package.json"), "utf-8"),
+    );
+    return pkg.version ?? "0.0.0";
+  } catch {
+    // fall back to placeholder; CLI remains functional
+    return "0.0.0";
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new top-level `octopus update` command that updates the CLI to the latest version published on npm.

- Fetches the latest `@octp/cli` version from the npm registry
- Compares against the currently installed version (semver)
- Installs the latest via `npm install -g @octp/cli@latest` when newer
- `--check` flag: only reports whether an update is available, without installing
- Graceful messaging when already up to date or when install fails (falls back to suggesting the manual command)

## Behavior
Already on latest:
```
ℹ Current version: 0.1.15
ℹ Latest version:  0.1.15
✓ You're already on the latest version.
```

New version available (`--check`):
```
ℹ Current version: 0.1.0
ℹ Latest version:  0.1.15
! A new version is available (0.1.15). Run `octopus update` to install it.
```

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `octopus update --check` verified against the live npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)